### PR TITLE
refactor: データセットと saved_models をリポジトリ外で管理

### DIFF
--- a/configs/gcn/cpu-train-3200.json
+++ b/configs/gcn/cpu-train-3200.json
@@ -2,16 +2,13 @@
     "expt_name": "actual",
     "gpu_id": "0",
     "use_gpu": false,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "random",
-
     "num_train_data": 3200,
     "num_test_data": 100,
     "num_val_data": 100,
@@ -22,31 +19,24 @@
     "capacity_higher": 10000,
     "demand_lower": 1,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_in": 30,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 8,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_epoch": false,
     "load_saved_model": false,

--- a/configs/gcn/load_saved_model.json
+++ b/configs/gcn/load_saved_model.json
@@ -2,16 +2,13 @@
     "expt_name": "load_saved_model",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "random",
-
     "num_train_data": 100,
     "num_test_data": 20,
     "num_val_data": 20,
@@ -22,31 +19,24 @@
     "capacity_higher": 10000,
     "demand_lower": 1,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_in": 30,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 5,
     "val_every": 2,
     "test_every": 2,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": false,
     "save_every_epoch": false,
     "load_saved_model": true,

--- a/configs/gcn/load_specific_epoch.json
+++ b/configs/gcn/load_specific_epoch.json
@@ -2,16 +2,13 @@
     "expt_name": "load_specific_epoch",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "random",
-
     "num_train_data": 100,
     "num_test_data": 20,
     "num_val_data": 20,
@@ -22,31 +19,24 @@
     "capacity_higher": 10000,
     "demand_lower": 1,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_in": 30,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 5,
     "val_every": 2,
     "test_every": 2,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": false,
     "save_every_epoch": false,
     "load_saved_model": true,

--- a/configs/gcn/nsfnet_10_commodities.json
+++ b/configs/gcn/nsfnet_10_commodities.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_10_commodities",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,30 +19,23 @@
     "capacity_higher": 5000,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_epoch": false,
     "load_saved_model": false,

--- a/configs/gcn/nsfnet_15_commodities.json
+++ b/configs/gcn/nsfnet_15_commodities.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_15_commodities",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,30 +19,23 @@
     "capacity_higher": 7500,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_epoch": false,
     "load_saved_model": false,

--- a/configs/gcn/nsfnet_20_commodities.json
+++ b/configs/gcn/nsfnet_20_commodities.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_20_commodities",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,30 +19,23 @@
     "capacity_higher": 10000,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_epoch": false,
     "load_saved_model": false,

--- a/configs/gcn/nsfnet_25_commodities.json
+++ b/configs/gcn/nsfnet_25_commodities.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_25_commodities",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,30 +19,23 @@
     "capacity_higher": 12500,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_epoch": false,
     "load_saved_model": false,

--- a/configs/gcn/nsfnet_5_commodities.json
+++ b/configs/gcn/nsfnet_5_commodities.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_5_commodities",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,30 +19,23 @@
     "capacity_higher": 10000,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 8,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_epoch": false,
     "load_saved_model": false,

--- a/configs/gcn/with_model_saving.json
+++ b/configs/gcn/with_model_saving.json
@@ -2,16 +2,13 @@
     "expt_name": "with_model_saving",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "random",
-
     "num_train_data": 100,
     "num_test_data": 20,
     "num_val_data": 20,
@@ -22,31 +19,24 @@
     "capacity_higher": 10000,
     "demand_lower": 1,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_in": 30,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_epoch": true,
     "load_saved_model": false,

--- a/configs/rl_ksp/nsfnet_10_commodities_rl.json
+++ b/configs/rl_ksp/nsfnet_10_commodities_rl.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_10_commodities_rl",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,29 +19,23 @@
     "capacity_higher": 5000,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
     "_comment": "=== Reinforcement Learning Parameters ===",
     "K": 10,
     "n_action": 20,
@@ -59,10 +50,12 @@
     "gamma": 0.85,
     "episodes": 3200,
     "test_episodes": 320,
-    "hidden_dims": [64, 64, 64],
-    
+    "hidden_dims": [
+        64,
+        64,
+        64
+    ],
     "_comment_model_saving": "=== Model Saving Parameters ===",
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_episode": false,
     "save_every_n_episodes": 1000000,

--- a/configs/rl_ksp/nsfnet_15_commodities_rl.json
+++ b/configs/rl_ksp/nsfnet_15_commodities_rl.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_15_commodities_rl",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,29 +19,23 @@
     "capacity_higher": 7500,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
     "_comment": "=== Reinforcement Learning Parameters ===",
     "K": 10,
     "n_action": 20,
@@ -59,10 +50,12 @@
     "gamma": 0.85,
     "episodes": 3200,
     "test_episodes": 320,
-    "hidden_dims": [64, 64, 64],
-    
+    "hidden_dims": [
+        64,
+        64,
+        64
+    ],
     "_comment_model_saving": "=== Model Saving Parameters ===",
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_episode": false,
     "save_every_n_episodes": 1000000,

--- a/configs/rl_ksp/nsfnet_20_commodities_rl.json
+++ b/configs/rl_ksp/nsfnet_20_commodities_rl.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_20_commodities_rl",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,29 +19,23 @@
     "capacity_higher": 10000,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
     "_comment": "=== Reinforcement Learning Parameters ===",
     "K": 10,
     "n_action": 20,
@@ -59,10 +50,12 @@
     "gamma": 0.85,
     "episodes": 3200,
     "test_episodes": 320,
-    "hidden_dims": [64, 64, 64],
-    
+    "hidden_dims": [
+        64,
+        64,
+        64
+    ],
     "_comment_model_saving": "=== Model Saving Parameters ===",
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_episode": false,
     "save_every_n_episodes": 1000000,

--- a/configs/rl_ksp/nsfnet_5_commodities_rl.json
+++ b/configs/rl_ksp/nsfnet_5_commodities_rl.json
@@ -2,16 +2,13 @@
     "expt_name": "nsfnet_5_commodities_rl",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 3200,
     "num_test_data": 320,
     "num_val_data": 320,
@@ -22,29 +19,23 @@
     "capacity_higher": 2500,
     "demand_lower": 5,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 10,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
     "_comment": "=== Reinforcement Learning Parameters ===",
     "K": 10,
     "n_action": 20,
@@ -59,10 +50,12 @@
     "gamma": 0.85,
     "episodes": 3200,
     "test_episodes": 320,
-    "hidden_dims": [64, 64, 64],
-    
+    "hidden_dims": [
+        64,
+        64,
+        64
+    ],
     "_comment_model_saving": "=== Model Saving Parameters ===",
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_episode": false,
     "save_every_n_episodes": 1000000,

--- a/configs/rl_ksp/rl_config.json
+++ b/configs/rl_ksp/rl_config.json
@@ -2,16 +2,13 @@
     "expt_name": "rl_training",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 100,
     "num_test_data": 20,
     "num_val_data": 20,
@@ -22,30 +19,24 @@
     "capacity_higher": 10000,
     "demand_lower": 1,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_in": 30,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 3,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
     "_comment": "=== Reinforcement Learning Parameters ===",
     "K": 10,
     "n_action": 20,
@@ -60,10 +51,12 @@
     "gamma": 0.85,
     "episodes": 100,
     "test_episodes": 20,
-    "hidden_dims": [32, 32, 32],
-    
+    "hidden_dims": [
+        32,
+        32,
+        32
+    ],
     "_comment_model_saving": "=== Model Saving Parameters ===",
-    "models_dir": "./saved_models",
     "save_model": true,
     "save_every_episode": false,
     "save_every_n_episodes": 50,

--- a/configs/rl_ksp/rl_load_saved_model.json
+++ b/configs/rl_ksp/rl_load_saved_model.json
@@ -2,16 +2,13 @@
     "expt_name": "rl_load_saved_model",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 100,
     "num_test_data": 20,
     "num_val_data": 20,
@@ -22,31 +19,25 @@
     "capacity_higher": 10000,
     "demand_lower": 1,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_in": 30,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 3,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "_comment": "=== Reinforcement Learning Parameters ===",
+    "_comment": "=== Model Loading Parameters ===",
     "K": 10,
     "n_action": 20,
     "max_step": 20,
@@ -60,10 +51,11 @@
     "gamma": 0.85,
     "episodes": 100,
     "test_episodes": 20,
-    "hidden_dims": [32, 32, 32],
-    
-    "_comment": "=== Model Loading Parameters ===",
-    "models_dir": "./saved_models",
+    "hidden_dims": [
+        32,
+        32,
+        32
+    ],
     "save_model": false,
     "save_every_episode": false,
     "save_every_n_episodes": 0,

--- a/configs/rl_ksp/rl_with_model_saving.json
+++ b/configs/rl_ksp/rl_with_model_saving.json
@@ -2,16 +2,13 @@
     "expt_name": "rl_training_with_saving",
     "gpu_id": "0",
     "use_gpu": true,
-
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "nsfnet",
-
     "num_train_data": 100,
     "num_test_data": 20,
     "num_val_data": 20,
@@ -22,31 +19,25 @@
     "capacity_higher": 10000,
     "demand_lower": 1,
     "demand_higher": 500,
-        
     "node_dim": 10,
     "voc_nodes_in": 30,
     "voc_nodes_out": 2,
     "voc_edges_in": 3,
     "voc_edges_out": 2,
-
     "beam_size": 10,
     "hidden_dim": 64,
     "num_layers": 10,
     "mlp_layers": 2,
     "aggregation": "mean",
-
     "max_epochs": 3,
     "val_every": 3,
     "test_every": 3,
-
     "batch_size": 20,
     "accumulation_steps": 1,
-
     "learning_rate": 0.0005,
     "decay_rate": 1.5,
     "dropout_rate": 0.5,
-
-    "_comment": "=== Reinforcement Learning Parameters ===",
+    "_comment": "=== Model Saving Parameters ===",
     "K": 10,
     "n_action": 20,
     "max_step": 20,
@@ -60,10 +51,11 @@
     "gamma": 0.85,
     "episodes": 100,
     "test_episodes": 20,
-    "hidden_dims": [32, 32, 32],
-    
-    "_comment": "=== Model Saving Parameters ===",
-    "models_dir": "./saved_models",
+    "hidden_dims": [
+        32,
+        32,
+        32
+    ],
     "save_model": true,
     "save_every_episode": false,
     "save_every_n_episodes": 100,

--- a/configs/seqflowrl/seqflowrl_base.json
+++ b/configs/seqflowrl/seqflowrl_base.json
@@ -2,21 +2,17 @@
     "_comment_meta": "=== SeqFlowRL: Sequential Flow Reinforcement Learning ===",
     "_description": "Hybrid approach combining GCN and Teal methods for network routing",
     "_design_decisions": "All design points confirmed - see git history for design docs",
-
     "expt_name": "seqflowrl_base",
     "gpu_id": "0",
     "use_gpu": true,
-
     "_comment_data": "=== Data Configuration ===",
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "random",
-
     "num_train_data": 3200,
     "num_val_data": 320,
     "num_test_data": 320,
@@ -27,48 +23,52 @@
     "capacity_higher": 10000,
     "demand_lower": 5,
     "demand_higher": 500,
-
     "_comment_model": "=== Model Architecture (Decision #6 confirmed) ===",
     "hidden_dim": 128,
     "num_layers": 8,
     "mlp_layers": 3,
     "aggregation": "mean",
     "dropout_rate": 0.3,
-
     "_comment_action": "=== Action Space (Decision #2-A confirmed) ===",
     "action_type": "node",
-    "_action_type_options": ["node", "edge"],
+    "_action_type_options": [
+        "node",
+        "edge"
+    ],
     "_action_type_note": "node: Node-level action (default, confirmed), edge: Edge-level action (experimental)",
     "policy_head_mlp_layers": 2,
-
     "_comment_value": "=== Value Network (Decision #2-B confirmed) ===",
     "value_head_mlp_layers": 3,
     "value_type": "global",
     "_value_note": "Global value: all nodes × all commodities (confirmed)",
-
     "_comment_rollout": "=== Sequential Rollout (Decision #3 confirmed) ===",
     "gnn_update_frequency": "per_commodity",
-    "_gnn_update_options": ["never", "per_commodity", "per_step"],
+    "_gnn_update_options": [
+        "never",
+        "per_commodity",
+        "per_step"
+    ],
     "_gnn_update_note": "per_commodity: default (confirmed), never/per_step: experimental",
     "sampling_temperature": 1.0,
     "sampling_top_p": 0.9,
     "max_path_length": 20,
     "_path_note": "Maximum hops per commodity to prevent infinite loops",
-
     "_comment_rl": "=== RL Algorithm (Decision #4 confirmed) ===",
     "rl_algorithm": "a2c",
-    "_rl_options": ["a2c", "ppo", "reinforce_baseline"],
+    "_rl_options": [
+        "a2c",
+        "ppo",
+        "reinforce_baseline"
+    ],
     "_rl_note": "a2c: default (confirmed), ppo: experimental upgrade",
     "entropy_weight": 0.01,
     "value_loss_weight": 0.5,
     "gamma": 0.99,
     "_gamma_note": "Discount factor for future rewards",
-
     "_comment_ppo": "=== PPO Specific (Experimental) ===",
     "ppo_epsilon": 0.2,
     "ppo_epochs": 4,
     "_ppo_note": "Only used if rl_algorithm='ppo'",
-
     "_comment_reward": "=== Reward Function ===",
     "reward_function_version": "continuous_v1",
     "_reward_formula": "reward = 2.0 - 2.0 * load_factor",
@@ -76,7 +76,6 @@
     "rl_use_smooth_penalty": true,
     "rl_penalty_lambda": 5.0,
     "_penalty_note": "Smooth penalty for capacity constraint violations",
-
     "_comment_training": "=== Training Configuration ===",
     "max_epochs": 30,
     "val_every": 10,
@@ -87,7 +86,6 @@
     "decay_rate": 1.2,
     "lr_scheduler": "step",
     "_lr_note": "Step LR with decay every 10 epochs",
-
     "_comment_pretrained": "=== Pre-trained Model (Decision #5 confirmed) ===",
     "two_phase_training": true,
     "_two_phase_note": "Phase 1: Supervised pre-training, Phase 2: RL fine-tuning (confirmed)",
@@ -95,7 +93,6 @@
     "pretrained_model_path": "saved_models/supervised_pretrained.pt",
     "supervised_config": "configs/gcn/supervised_pretraining.json",
     "_pretrain_note": "Set load_pretrained_model=true to use 2-phase training",
-
     "_comment_optimization": "=== Optimization ===",
     "optimizer": "adam",
     "adam_beta1": 0.9,
@@ -103,33 +100,27 @@
     "weight_decay": 0.0001,
     "grad_clip_norm": 1.0,
     "_grad_clip_note": "Gradient clipping to prevent explosion",
-
     "_comment_exploration": "=== Exploration Strategy ===",
     "use_adaptive_entropy": false,
     "initial_entropy": 0.01,
     "min_entropy": 0.001,
     "entropy_decay_rate": 0.995,
     "_exploration_note": "Set use_adaptive_entropy=true for dynamic entropy adjustment",
-
     "_comment_advanced": "=== Advanced Options (See improvement proposals) ===",
     "use_curiosity": false,
     "curiosity_weight": 0.1,
     "epsilon_greedy": 0.0,
     "_advanced_note": "See git history for design docs",
-
     "_comment_logging": "=== Logging and Checkpointing ===",
     "log_every": 10,
     "save_every": 10,
     "save_best_only": true,
-    "checkpoint_dir": "saved_models/seqflowrl/",
     "tensorboard_dir": "runs/seqflowrl/",
-
     "_comment_eval": "=== Evaluation ===",
     "eval_deterministic": true,
     "_eval_note": "Use greedy action selection during evaluation",
     "eval_beam_search": false,
     "beam_size": 10,
-
     "_comment_debug": "=== Debug Options ===",
     "debug_mode": false,
     "verbose": true,

--- a/configs/seqflowrl/seqflowrl_mini.json
+++ b/configs/seqflowrl/seqflowrl_mini.json
@@ -2,21 +2,17 @@
     "_comment_meta": "=== SeqFlowRL: Sequential Flow Reinforcement Learning ===",
     "_description": "Hybrid approach combining GCN and Teal methods for network routing",
     "_design_decisions": "All design points confirmed - see git history for design docs",
-
     "expt_name": "seqflowrl_base",
     "gpu_id": "0",
     "use_gpu": true,
-
     "_comment_data": "=== Data Configuration ===",
     "graph_filepath": "./data/graph.gml",
     "edge_numbering_filepath": "./data/edge_numbering_file.csv",
     "train_filepath": "./data/gragh.gml",
     "val_filepath": "./data/tsp10_val_concorde.txt",
     "test_filepath": "./data/tsp10_test_concorde.txt",
-
     "solver_type": "pulp",
     "graph_model": "random",
-
     "num_train_data": 320,
     "num_val_data": 32,
     "num_test_data": 32,
@@ -27,48 +23,52 @@
     "capacity_higher": 10000,
     "demand_lower": 5,
     "demand_higher": 500,
-
     "_comment_model": "=== Model Architecture (Decision #6 confirmed) ===",
     "hidden_dim": 128,
     "num_layers": 8,
     "mlp_layers": 3,
     "aggregation": "mean",
     "dropout_rate": 0.3,
-
     "_comment_action": "=== Action Space (Decision #2-A confirmed) ===",
     "action_type": "node",
-    "_action_type_options": ["node", "edge"],
+    "_action_type_options": [
+        "node",
+        "edge"
+    ],
     "_action_type_note": "node: Node-level action (default, confirmed), edge: Edge-level action (experimental)",
     "policy_head_mlp_layers": 2,
-
     "_comment_value": "=== Value Network (Decision #2-B confirmed) ===",
     "value_head_mlp_layers": 3,
     "value_type": "global",
     "_value_note": "Global value: all nodes × all commodities (confirmed)",
-
     "_comment_rollout": "=== Sequential Rollout (Decision #3 confirmed) ===",
     "gnn_update_frequency": "per_commodity",
-    "_gnn_update_options": ["never", "per_commodity", "per_step"],
+    "_gnn_update_options": [
+        "never",
+        "per_commodity",
+        "per_step"
+    ],
     "_gnn_update_note": "per_commodity: default (confirmed), never/per_step: experimental",
     "sampling_temperature": 1.0,
     "sampling_top_p": 0.9,
     "max_path_length": 20,
     "_path_note": "Maximum hops per commodity to prevent infinite loops",
-
     "_comment_rl": "=== RL Algorithm (Decision #4 confirmed) ===",
     "rl_algorithm": "a2c",
-    "_rl_options": ["a2c", "ppo", "reinforce_baseline"],
+    "_rl_options": [
+        "a2c",
+        "ppo",
+        "reinforce_baseline"
+    ],
     "_rl_note": "a2c: default (confirmed), ppo: experimental upgrade",
     "entropy_weight": 0.01,
     "value_loss_weight": 0.5,
     "gamma": 0.99,
     "_gamma_note": "Discount factor for future rewards",
-
     "_comment_ppo": "=== PPO Specific (Experimental) ===",
     "ppo_epsilon": 0.2,
     "ppo_epochs": 4,
     "_ppo_note": "Only used if rl_algorithm='ppo'",
-
     "_comment_reward": "=== Reward Function ===",
     "reward_function_version": "continuous_v1",
     "_reward_formula": "reward = 2.0 - 2.0 * load_factor",
@@ -76,7 +76,6 @@
     "rl_use_smooth_penalty": true,
     "rl_penalty_lambda": 5.0,
     "_penalty_note": "Smooth penalty for capacity constraint violations",
-
     "_comment_training": "=== Training Configuration ===",
     "max_epochs": 30,
     "val_every": 10,
@@ -87,7 +86,6 @@
     "decay_rate": 1.2,
     "lr_scheduler": "step",
     "_lr_note": "Step LR with decay every 10 epochs",
-
     "_comment_pretrained": "=== Pre-trained Model (Decision #5 confirmed) ===",
     "two_phase_training": true,
     "_two_phase_note": "Phase 1: Supervised pre-training, Phase 2: RL fine-tuning (confirmed)",
@@ -95,7 +93,6 @@
     "pretrained_model_path": "saved_models/supervised_pretrained.pt",
     "supervised_config": "configs/gcn/supervised_pretraining.json",
     "_pretrain_note": "Set load_pretrained_model=true to use 2-phase training",
-
     "_comment_optimization": "=== Optimization ===",
     "optimizer": "adam",
     "adam_beta1": 0.9,
@@ -103,33 +100,27 @@
     "weight_decay": 0.0001,
     "grad_clip_norm": 1.0,
     "_grad_clip_note": "Gradient clipping to prevent explosion",
-
     "_comment_exploration": "=== Exploration Strategy ===",
     "use_adaptive_entropy": false,
     "initial_entropy": 0.01,
     "min_entropy": 0.001,
     "entropy_decay_rate": 0.995,
     "_exploration_note": "Set use_adaptive_entropy=true for dynamic entropy adjustment",
-
     "_comment_advanced": "=== Advanced Options (See improvement proposals) ===",
     "use_curiosity": false,
     "curiosity_weight": 0.1,
     "epsilon_greedy": 0.0,
     "_advanced_note": "See git history for design docs",
-
     "_comment_logging": "=== Logging and Checkpointing ===",
     "log_every": 10,
     "save_every": 10,
     "save_best_only": true,
-    "checkpoint_dir": "saved_models/seqflowrl/",
     "tensorboard_dir": "runs/seqflowrl/",
-
     "_comment_eval": "=== Evaluation ===",
     "eval_deterministic": true,
     "_eval_note": "Use greedy action selection during evaluation",
     "eval_beam_search": false,
     "beam_size": 10,
-
     "_comment_debug": "=== Debug Options ===",
     "debug_mode": false,
     "verbose": true,

--- a/scripts/common/generate_data.py
+++ b/scripts/common/generate_data.py
@@ -13,6 +13,7 @@ import shutil
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
 from src.common.config.config_manager import ConfigManager
+from src.common.config.paths import get_mode_dir, get_dataset_dir
 from src.common.data_management.create_data_files import create_data_files
 
 def main():
@@ -40,6 +41,7 @@ def main():
     try:
         config_manager = ConfigManager(args.config)
         config = config_manager.get_config()
+        print(f"Dataset directory: {get_dataset_dir(config)}")
         print(f"Number of commodities: {config.num_commodities}")
         print(f"Number of nodes: {config.num_nodes}")
         print(f"Train data: {config.num_train_data}")
@@ -48,29 +50,29 @@ def main():
     except Exception as e:
         print(f"Error loading config: {e}")
         sys.exit(1)
-    
+
     # 既存データの確認と削除
     existing_dirs = []
     for mode in args.modes:
-        data_dir = f"./data/{mode}_data"
-        if os.path.exists(data_dir):
+        data_dir = get_mode_dir(mode, config)
+        if data_dir.exists():
             existing_dirs.append(data_dir)
-    
+
     if existing_dirs:
         print(f"\n既存のデータディレクトリが見つかりました:")
         for dir_path in existing_dirs:
             print(f"  - {dir_path}")
-        
+
         if not args.force:
             ans = input("\n既存データを削除して再生成しますか？ (y/n): ").strip().lower()
             if ans not in ["y", "yes"]:
                 print("データ生成をキャンセルしました。")
                 sys.exit(0)
-    
+
     # 既存データの削除
     for mode in args.modes:
-        data_dir = f"./data/{mode}_data"
-        if os.path.exists(data_dir):
+        data_dir = get_mode_dir(mode, config)
+        if data_dir.exists():
             shutil.rmtree(data_dir)
             print(f"削除: {data_dir}")
     
@@ -96,9 +98,9 @@ def main():
     # 生成されたデータの確認
     print("\n生成されたデータ:")
     for mode in args.modes:
-        data_dir = f"./data/{mode}_data"
-        if os.path.exists(data_dir):
-            file_count = len([f for f in os.listdir(data_dir) if f.endswith('.pkl')])
+        data_dir = get_mode_dir(mode, config)
+        if data_dir.exists():
+            file_count = sum(1 for _ in data_dir.rglob("*") if _.is_file())
             print(f"  - {data_dir}: {file_count} files")
         else:
             print(f"  - {data_dir}: 生成されませんでした")

--- a/scripts/gcn/train_gcn.py
+++ b/scripts/gcn/train_gcn.py
@@ -15,31 +15,7 @@ from src.gcn.train.trainer import Trainer
 from src.gcn.train.evaluator import Evaluator
 from src.gcn.train.metrics import MetricsLogger
 from src.common.config.config_manager import ConfigManager
-
-
-def _check_data_exists():
-    """データディレクトリの存在を確認"""
-    data_dirs = ['./data/train_data', './data/val_data', './data/test_data']
-    required_subdirs = ['commodity_file', 'graph_file', 'node_flow_file']
-
-    for data_dir in data_dirs:
-        if not os.path.exists(data_dir):
-            return False
-
-        # 必要なサブディレクトリが存在するかチェック
-        for subdir in required_subdirs:
-            subdir_path = os.path.join(data_dir, subdir)
-            if not os.path.exists(subdir_path):
-                return False
-
-        # commodity_fileディレクトリに数値名のサブディレクトリが存在するかチェック
-        commodity_dir = os.path.join(data_dir, 'commodity_file')
-        subdirs = [d for d in os.listdir(commodity_dir)
-                  if os.path.isdir(os.path.join(commodity_dir, d)) and d.isdigit()]
-        if len(subdirs) == 0:
-            return False
-
-    return True
+from src.common.config.paths import dataset_exists
 
 
 def main():
@@ -54,16 +30,16 @@ def main():
     print("GCN (GRAPH CONVOLUTIONAL NETWORK) TRAINING")
     print("="*60)
 
-    # データの存在確認
-    if not _check_data_exists():
-        print("データが存在しません。以下のコマンドでデータを生成してください:")
-        print(f"python scripts/common/generate_data.py --config {args.config}")
-        sys.exit(1)
-
     # 設定の初期化
     config_manager = ConfigManager(args.config)
     config = config_manager.get_config()
     dtypeFloat, dtypeLong = config_manager.get_dtypes()
+
+    # データの存在確認
+    if not dataset_exists(config):
+        print("データが存在しません。以下のコマンドでデータを生成してください:")
+        print(f"python scripts/common/generate_data.py --config {args.config}")
+        sys.exit(1)
 
     # トレーナーとエバリュエーターの初期化
     trainer = Trainer(config, dtypeFloat, dtypeLong)

--- a/scripts/gcn/tune_hyperparameters.py
+++ b/scripts/gcn/tune_hyperparameters.py
@@ -12,6 +12,8 @@ import sys
 from datetime import datetime
 
 from src.gcn.tuning.hyperparameter_tuner import HyperparameterTuner
+from src.common.config.config_manager import ConfigManager
+from src.common.config.paths import dataset_exists
 
 
 def main():
@@ -58,8 +60,9 @@ def main():
         print(f"Error: Tuning config file not found: {args.tuning_config}")
         sys.exit(1)
 
-    # データの存在確認
-    if not _check_data_exists():
+    # データの存在確認（ベース config に基づく）
+    base_config = ConfigManager(args.config).get_config()
+    if not dataset_exists(base_config):
         print("Error: Required data directories not found.")
         print("Please run 'python scripts/common/generate_data.py' first to create training data.")
         sys.exit(1)
@@ -136,31 +139,6 @@ def main():
         import traceback
         traceback.print_exc()
         sys.exit(1)
-
-
-def _check_data_exists():
-    """データディレクトリの存在を確認"""
-    data_dirs = ['./data/train_data', './data/val_data', './data/test_data']
-    required_subdirs = ['commodity_file', 'graph_file', 'node_flow_file']
-
-    for data_dir in data_dirs:
-        if not os.path.exists(data_dir):
-            return False
-
-        # 必要なサブディレクトリが存在するかチェック
-        for subdir in required_subdirs:
-            subdir_path = os.path.join(data_dir, subdir)
-            if not os.path.exists(subdir_path):
-                return False
-
-        # commodity_fileディレクトリに数値名のサブディレクトリが存在するかチェック
-        commodity_dir = os.path.join(data_dir, 'commodity_file')
-        subdirs = [d for d in os.listdir(commodity_dir)
-                  if os.path.isdir(os.path.join(commodity_dir, d)) and d.isdigit()]
-        if len(subdirs) == 0:
-            return False
-
-    return True
 
 
 def _create_best_config(best_result, base_config_path, results_dir):

--- a/scripts/gcn/two_phase_training.py
+++ b/scripts/gcn/two_phase_training.py
@@ -22,6 +22,8 @@ from pathlib import Path
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
 sys.path.insert(0, project_root)
 
+from src.common.config.paths import get_model_root
+
 
 def run_training_phase(config_path, phase_name, pretrained_model_path=None):
     """
@@ -110,7 +112,7 @@ def main():
     parser.add_argument('--skip-supervised', action='store_true',
                        help='Skip supervised pre-training (use existing model)')
     parser.add_argument('--pretrained-model', type=str,
-                       default='saved_models/supervised_pretrained.pt',
+                       default=str(get_model_root() / 'supervised_pretrained.pt'),
                        help='Path to save/load pre-trained model')
     args = parser.parse_args()
 
@@ -144,7 +146,7 @@ def main():
             return 1
 
         # Automatically find the latest supervised model (just trained)
-        saved_models_dir = os.path.join(project_root, 'saved_models')
+        saved_models_dir = str(get_model_root())
         if os.path.exists(saved_models_dir):
             models = [f for f in os.listdir(saved_models_dir) if f.endswith('.pt')]
             if models:
@@ -155,16 +157,16 @@ def main():
                 args.pretrained_model = os.path.join(saved_models_dir, latest_model)
                 print(f"\n✓ Automatically using latest supervised model: {latest_model}")
             else:
-                print("\n✗ No model files found in saved_models directory.")
+                print(f"\n✗ No model files found in {saved_models_dir}.")
                 return 1
         else:
-            print("\n✗ saved_models directory does not exist.")
+            print(f"\n✗ Model directory does not exist: {saved_models_dir}")
             return 1
 
     else:
         print("\n⏭  Skipping supervised pre-training (using existing model)")
         # When skipping Phase 1, automatically find the latest model
-        saved_models_dir = os.path.join(project_root, 'saved_models')
+        saved_models_dir = str(get_model_root())
         if os.path.exists(saved_models_dir):
             models = [f for f in os.listdir(saved_models_dir) if f.endswith('.pt')]
             if models:
@@ -174,10 +176,10 @@ def main():
                 args.pretrained_model = os.path.join(saved_models_dir, latest_model)
                 print(f"✓ Automatically using latest model: {latest_model}")
             else:
-                print("\n✗ No model files found in saved_models directory.")
+                print(f"\n✗ No model files found in {saved_models_dir}.")
                 return 1
         else:
-            print("\n✗ saved_models directory does not exist.")
+            print(f"\n✗ Model directory does not exist: {saved_models_dir}")
             return 1
 
     # Phase 2: RL Fine-tuning

--- a/scripts/rl_ksp/train_rl_ksp.py
+++ b/scripts/rl_ksp/train_rl_ksp.py
@@ -13,31 +13,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../.
 
 from src.rl_ksp.train.rl_trainer import RLTrainer
 from src.common.config.config_manager import ConfigManager
-
-
-def _check_data_exists():
-    """データディレクトリの存在を確認"""
-    data_dirs = ['./data/train_data', './data/val_data', './data/test_data']
-    required_subdirs = ['commodity_file', 'graph_file', 'node_flow_file']
-
-    for data_dir in data_dirs:
-        if not os.path.exists(data_dir):
-            return False
-
-        # 必要なサブディレクトリが存在するかチェック
-        for subdir in required_subdirs:
-            subdir_path = os.path.join(data_dir, subdir)
-            if not os.path.exists(subdir_path):
-                return False
-
-        # commodity_fileディレクトリに数値名のサブディレクトリが存在するかチェック
-        commodity_dir = os.path.join(data_dir, 'commodity_file')
-        subdirs = [d for d in os.listdir(commodity_dir)
-                  if os.path.isdir(os.path.join(commodity_dir, d)) and d.isdigit()]
-        if len(subdirs) == 0:
-            return False
-
-    return True
+from src.common.config.paths import dataset_exists
 
 
 def main():
@@ -52,15 +28,15 @@ def main():
     print("RL-KSP (REINFORCEMENT LEARNING WITH K-SHORTEST PATHS)")
     print("="*60)
 
-    # データの存在確認
-    if not _check_data_exists():
-        print("データが存在しません。以下のコマンドでデータを生成してください:")
-        print(f"python scripts/common/generate_data.py --config {args.config}")
-        sys.exit(1)
-
     # 設定の初期化
     config_manager = ConfigManager(args.config)
     config = config_manager.get_config()
+
+    # データの存在確認
+    if not dataset_exists(config):
+        print("データが存在しません。以下のコマンドでデータを生成してください:")
+        print(f"python scripts/common/generate_data.py --config {args.config}")
+        sys.exit(1)
 
     # RL トレーナーの初期化
     rl_trainer = RLTrainer(dict(config))

--- a/scripts/seq_flow_rl/train_seqflowrl.py
+++ b/scripts/seq_flow_rl/train_seqflowrl.py
@@ -16,30 +16,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../.
 
 from src.seq_flow_rl.training import SeqFlowRLTrainer
 from src.common.config.config_manager import ConfigManager
+from src.common.config.paths import dataset_exists
 from src.common.data_management.dataset_reader import DatasetReader
-
-
-def _check_data_exists():
-    """Check if data directories exist."""
-    data_dirs = ['./data/train_data', './data/val_data', './data/test_data']
-    required_subdirs = ['commodity_file', 'graph_file', 'node_flow_file']
-
-    for data_dir in data_dirs:
-        if not os.path.exists(data_dir):
-            return False
-
-        for subdir in required_subdirs:
-            subdir_path = os.path.join(data_dir, subdir)
-            if not os.path.exists(subdir_path):
-                return False
-
-        commodity_dir = os.path.join(data_dir, 'commodity_file')
-        subdirs = [d for d in os.listdir(commodity_dir)
-                  if os.path.isdir(os.path.join(commodity_dir, d)) and d.isdigit()]
-        if len(subdirs) == 0:
-            return False
-
-    return True
 
 
 def create_dataloaders(config, dtypeFloat, dtypeLong):
@@ -60,8 +38,8 @@ def create_dataloaders(config, dtypeFloat, dtypeLong):
     num_val_data = config.get('num_val_data', 1000)
 
     # Create dataset readers (they are iterators)
-    train_dataset = DatasetReader(num_train_data, batch_size, 'train')
-    val_dataset = DatasetReader(num_val_data, batch_size, 'val')
+    train_dataset = DatasetReader(num_train_data, batch_size, 'train', config)
+    val_dataset = DatasetReader(num_val_data, batch_size, 'val', config)
 
     return train_dataset, val_dataset
 
@@ -89,15 +67,15 @@ def main():
     print("="*70)
     print(f"Config: {args.config}")
 
-    # Check if data exists
-    if not _check_data_exists():
-        print("\n⚠️  Data not found. Please generate data first:")
-        print(f"    python scripts/common/generate_data.py --config {args.config}")
-        sys.exit(1)
-
     # Load configuration
     config_manager = ConfigManager(args.config)
     config = config_manager.get_config()
+
+    # Check if data exists
+    if not dataset_exists(config):
+        print("\n⚠️  Data not found. Please generate data first:")
+        print(f"    python scripts/common/generate_data.py --config {args.config}")
+        sys.exit(1)
     dtypeFloat, dtypeLong = config_manager.get_dtypes()
 
     # Override config with command line arguments

--- a/src/common/config/paths.py
+++ b/src/common/config/paths.py
@@ -1,0 +1,149 @@
+"""データセットとモデル保管場所の解決ヘルパー.
+
+データセットと学習済みモデルはコードリポジトリ外で管理する。
+パスの解決優先順位:
+
+1. 環境変数 (``GCN_UELB_DATA_ROOT`` / ``GCN_UELB_MODEL_ROOT``)
+2. config の ``data_root`` / ``model_root``
+3. デフォルト (プロジェクトルートと同階層の ``../ml-data/graph-convnet-uelb/``)
+
+ディレクトリ構造::
+
+    <Projects>/ml-data/graph-convnet-uelb/
+    ├── datasets/
+    │   └── {dataset_name}/
+    │       ├── train_data/
+    │       ├── val_data/
+    │       └── test_data/
+    └── saved_models/
+
+``dataset_name`` は config の ``dataset_name`` フィールド、なければ ``expt_name`` にフォールバック。
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+ENV_DATA_ROOT = "GCN_UELB_DATA_ROOT"
+ENV_MODEL_ROOT = "GCN_UELB_MODEL_ROOT"
+
+# プロジェクトルート (このファイルから 4 階層上: src/common/config/paths.py → repo)
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+# プロジェクトと同階層の ml-data/graph-convnet-uelb をデフォルトに
+_DEFAULT_BASE = _PROJECT_ROOT.parent / "ml-data" / "graph-convnet-uelb"
+DEFAULT_DATA_ROOT = _DEFAULT_BASE / "datasets"
+DEFAULT_MODEL_ROOT = _DEFAULT_BASE / "saved_models"
+
+
+def _config_get(config: Any, key: str) -> Optional[Any]:
+    if config is None:
+        return None
+    if hasattr(config, "get"):
+        try:
+            return config.get(key)
+        except TypeError:
+            pass
+    return getattr(config, key, None)
+
+
+def get_data_root(config: Any = None) -> Path:
+    """データセットを格納する親ディレクトリを返す."""
+    env_val = os.environ.get(ENV_DATA_ROOT)
+    if env_val:
+        return Path(env_val).expanduser()
+    cfg_val = _config_get(config, "data_root")
+    if cfg_val:
+        return Path(str(cfg_val)).expanduser()
+    return DEFAULT_DATA_ROOT
+
+
+def get_model_root(config: Any = None) -> Path:
+    """学習済みモデルを格納する親ディレクトリを返す."""
+    env_val = os.environ.get(ENV_MODEL_ROOT)
+    if env_val:
+        return Path(env_val).expanduser()
+    cfg_val = _config_get(config, "model_root")
+    if cfg_val:
+        return Path(str(cfg_val)).expanduser()
+    return DEFAULT_MODEL_ROOT
+
+
+def get_dataset_name(config: Any) -> str:
+    """config に紐付くデータセット名を返す.
+
+    ``dataset_name`` が無ければ ``expt_name`` にフォールバック。
+    """
+    name = _config_get(config, "dataset_name") or _config_get(config, "expt_name")
+    if not name:
+        raise ValueError(
+            "Config must specify 'dataset_name' (or 'expt_name' as fallback) "
+            "to locate the dataset directory."
+        )
+    return str(name)
+
+
+def get_dataset_dir(config: Any) -> Path:
+    """config に紐付くデータセットのルートディレクトリを返す."""
+    return get_data_root(config) / get_dataset_name(config)
+
+
+def get_mode_dir(mode: str, config: Any) -> Path:
+    """``train_data`` / ``val_data`` / ``test_data`` のディレクトリを返す."""
+    return get_dataset_dir(config) / f"{mode}_data"
+
+
+def get_exact_solution_file(mode: str, config: Any) -> Path:
+    """モード毎の exact_solution.csv のパスを返す."""
+    return get_mode_dir(mode, config) / "exact_solution.csv"
+
+
+def get_graph_file(mode: str, idx: int, config: Any) -> Path:
+    """個別グラフファイルのパスを返す (10件ごとに番号付けされたサブディレクトリ)."""
+    bucket = idx - (idx % 10)
+    return get_mode_dir(mode, config) / "graph_file" / str(bucket) / f"graph_{idx}.gml"
+
+
+def get_commodity_file(mode: str, idx: int, config: Any) -> Path:
+    bucket = idx - (idx % 10)
+    return (
+        get_mode_dir(mode, config)
+        / "commodity_file"
+        / str(bucket)
+        / f"commodity_data_{idx}.csv"
+    )
+
+
+def get_node_flow_file(mode: str, idx: int, config: Any) -> Path:
+    bucket = idx - (idx % 10)
+    return (
+        get_mode_dir(mode, config)
+        / "node_flow_file"
+        / str(bucket)
+        / f"node_flow_{idx}.csv"
+    )
+
+
+def dataset_exists(config: Any, modes: tuple = ("train", "val", "test")) -> bool:
+    """指定 config のデータセットが存在するかを確認する.
+
+    各モードディレクトリと必要なサブディレクトリ (commodity_file,
+    graph_file, node_flow_file) の存在をチェック。
+    """
+    required_subdirs = ("commodity_file", "graph_file", "node_flow_file")
+    for mode in modes:
+        mode_dir = get_mode_dir(mode, config)
+        if not mode_dir.exists():
+            return False
+        for sub in required_subdirs:
+            sub_dir = mode_dir / sub
+            if not sub_dir.exists():
+                return False
+            # 数値名のサブディレクトリ (0, 10, 20, ...) が1つ以上あるか
+            numeric_subs = [
+                d for d in sub_dir.iterdir() if d.is_dir() and d.name.isdigit()
+            ]
+            if not numeric_subs:
+                return False
+    return True

--- a/src/common/data_management/create_data_files.py
+++ b/src/common/data_management/create_data_files.py
@@ -3,6 +3,7 @@ import csv
 import networkx as nx
 from .data_maker import DataMaker
 from .exact_solution import SolveExactSolution
+from src.common.config.paths import get_mode_dir
 import torch
 
 def create_data_files(config, data_mode="test"):
@@ -16,10 +17,14 @@ def create_data_files(config, data_mode="test"):
     num_data = getattr(config, f'num_{data_mode}_data')
     solver_type = config.solver_type
     Maker = DataMaker(config)
-    exact_file_name = f"./data/{data_mode}_data/exact_solution.csv"
+
+    mode_dir = get_mode_dir(data_mode, config)
+    mode_dir.mkdir(parents=True, exist_ok=True)
+
+    exact_file_name = str(mode_dir / "exact_solution.csv")
     infinit_loop_count = 0
     incorrect_value_count = 0
-    
+
     if os.path.exists(exact_file_name):
         os.remove(exact_file_name)
 
@@ -30,20 +35,19 @@ def create_data_files(config, data_mode="test"):
 
         # ディレクトリ番号の定義
         file_number = data - (data % 10)
-        
+
         # ディレクトリ作成
         directories = ["graph_file", "commodity_file", "node_flow_file"]
         #directories = ["graph_file", "commodity_file", "edge_file", "node_flow_file", "edge_flow_file"]
         for directory in directories:
-            path = f"./data/{data_mode}_data/{directory}/{file_number}"
-            os.makedirs(path, exist_ok=True)
+            (mode_dir / directory / str(file_number)).mkdir(parents=True, exist_ok=True)
 
         # ファイル名の定義
-        graph_file_name = f"./data/{data_mode}_data/graph_file/{file_number}/graph_{data}.gml"
-        commodity_file_name = f"./data/{data_mode}_data/commodity_file/{file_number}/commodity_data_{data}.csv"
-        node_flow_file_name = f"./data/{data_mode}_data/node_flow_file/{file_number}/node_flow_{data}.csv"
-        #edge_file_name = f"./data/{data_mode}_data/edge_file/{file_number}/edge_numbering_{data}.csv"
-        #edge_flow_file_name = f"./data/{data_mode}_data/edge_flow_file/{file_number}/edge_flow_{data}.csv"
+        graph_file_name = str(mode_dir / "graph_file" / str(file_number) / f"graph_{data}.gml")
+        commodity_file_name = str(mode_dir / "commodity_file" / str(file_number) / f"commodity_data_{data}.csv")
+        node_flow_file_name = str(mode_dir / "node_flow_file" / str(file_number) / f"node_flow_{data}.csv")
+        #edge_file_name = str(mode_dir / "edge_file" / str(file_number) / f"edge_numbering_{data}.csv")
+        #edge_flow_file_name = str(mode_dir / "edge_flow_file" / str(file_number) / f"edge_flow_{data}.csv")
 
         # 作成したデータが適切でない場合のやり直し
         while True:

--- a/src/common/data_management/dataset_manager.py
+++ b/src/common/data_management/dataset_manager.py
@@ -2,38 +2,39 @@ import os
 import shutil
 from typing import Optional
 from .create_data_files import create_data_files
+from src.common.config.paths import get_mode_dir
 
 class DatasetManager:
     """データセットの作成と管理を担当するクラス"""
-    
+
     def __init__(self, config):
         self.config = config
-    
+
     def remake_dataset(self) -> bool:
         """データセットの再作成を確認"""
         ans = input("トレーニング・検証・テスト用データを再作成しますか？ (y/n): ").strip().lower()
         return ans in ["y", "yes"]
-    
+
     def create_all_datasets(self):
         """全てのデータセットを作成"""
         # 既存のデータを削除
         for mode in ["val", "test", "train"]:
-            data_dir = f"./data/{mode}_data"
-            if os.path.exists(data_dir):
+            data_dir = get_mode_dir(mode, self.config)
+            if data_dir.exists():
                 shutil.rmtree(data_dir)
-                print(f"Removed existing {mode} data directory")
-        
+                print(f"Removed existing {mode} data directory: {data_dir}")
+
         # 新しいデータを生成
         for mode in ["val", "test", "train"]:
             create_data_files(self.config, data_mode=mode)
-    
+
     def test_data_loading(self):
         """データローディングのテスト"""
         mode = "test"
         num_data = getattr(self.config, f'num_{mode}_data')
         batch_size = self.config.batch_size
         from .dataset_reader import DatasetReader
-        dataset = DatasetReader(num_data, batch_size, mode)
+        dataset = DatasetReader(num_data, batch_size, mode, self.config)
         print(f"Number of batches of size {batch_size}: {dataset.max_iter}")
         batch = next(iter(dataset))
         print("edges shape:", batch.edges.shape)

--- a/src/common/data_management/dataset_reader.py
+++ b/src/common/data_management/dataset_reader.py
@@ -5,6 +5,8 @@ import networkx as nx
 import csv
 import torch
 
+from src.common.config.paths import get_mode_dir
+
 class DotDict(dict):
     """Wrapper around in-built dict class to access members through the dot operation.
     d = DotDict(name="Alice", age=25)
@@ -25,17 +27,19 @@ class DatasetReader(object):
     """Iterator that reads UELB dataset files and yields mini-batches.
     """
 
-    def __init__(self, num_data, batch_size, mode):
+    def __init__(self, num_data, batch_size, mode, config):
         """
         Args:
-            num_nodes: Number of nodes
-            num_data: Number of data that will be generated
+            num_data: Number of data samples
             batch_size: Batch size
+            mode: 'train' / 'val' / 'test'
+            config: 設定オブジェクト (dataset_name / data_root 参照に使用)
         """
         self.num_data = num_data
         self.batch_size = batch_size
         self.mode = mode
         self.max_iter = (self.num_data // self.batch_size)
+        self.data_dir = get_mode_dir(mode, config)
 
     def __iter__(self):
         """
@@ -64,14 +68,15 @@ class DatasetReader(object):
         batch_commodities = []
         batch_load_factor = []
 
-        exact_solution_file = f'./data/{self.mode}_data/exact_solution.csv'
+        exact_solution_file = str(self.data_dir / 'exact_solution.csv')
         for i in range(start_idx, end_idx):
+            bucket = i - (i % 10)
             # define file path
-            graph_file = f'./data/{self.mode}_data/graph_file/{i-(i%10)}/graph_{i}.gml'
-            commodity_file = f'./data/{self.mode}_data/commodity_file/{i-(i%10)}/commodity_data_{i}.csv'
-            node_flow_file = f'./data/{self.mode}_data/node_flow_file/{i-(i%10)}/node_flow_{i}.csv'
-            edge_file = f'./data/{self.mode}_data/edge_file/{i-(i%10)}/edge_numbering_{i}.csv'
-            edge_flow_file = f'./data/{self.mode}_data/edge_flow_file/{i-(i%10)}/edge_flow_{i}.csv'
+            graph_file = str(self.data_dir / 'graph_file' / str(bucket) / f'graph_{i}.gml')
+            commodity_file = str(self.data_dir / 'commodity_file' / str(bucket) / f'commodity_data_{i}.csv')
+            node_flow_file = str(self.data_dir / 'node_flow_file' / str(bucket) / f'node_flow_{i}.csv')
+            edge_file = str(self.data_dir / 'edge_file' / str(bucket) / f'edge_numbering_{i}.csv')
+            edge_flow_file = str(self.data_dir / 'edge_flow_file' / str(bucket) / f'edge_flow_{i}.csv')
             
             """ Make a graph """
             G = nx.read_gml(graph_file,destringizer=int)

--- a/src/gcn/algorithms/algorithm_examples.py
+++ b/src/gcn/algorithms/algorithm_examples.py
@@ -12,6 +12,7 @@ from src.gcn.algorithms.beamsearch_uelb import BeamSearchAlgorithm
 from src.common.data_management.dataset_reader import DatasetReader
 from src.gcn.models.gcn_model import ResidualGatedGCNModel
 from src.common.config.config_manager import ConfigManager
+from src.common.config.paths import get_model_root
 
 def load_example_config(config_path: str) -> Dict[str, Any]:
     """アルゴリズム例用の設定を読み込み"""
@@ -20,8 +21,10 @@ def load_example_config(config_path: str) -> Dict[str, Any]:
 
 def find_model_path(model_config: Dict[str, Any]) -> Optional[str]:
     """設定に基づいてモデルパスを決定"""
-    model_dir = model_config.get('model_path', './saved_models')
-    
+    model_dir = model_config.get('model_path')
+    if not model_dir:
+        model_dir = str(get_model_root())
+
     if not os.path.exists(model_dir):
         return None
     
@@ -91,7 +94,7 @@ def create_real_prediction_data(batch_size, config_path, model_path):
     
     # テストデータの読み込み
     num_test_data = min(config.get('num_test_data', 20), batch_size * 10)  # 十分なデータを確保
-    dataset = DatasetReader(num_test_data, batch_size, 'test')
+    dataset = DatasetReader(num_test_data, batch_size, 'test', config)
     
     try:
         # 最初のバッチを取得
@@ -150,7 +153,7 @@ def create_sample_data(batch_size=2, num_nodes=10, num_commodities=5):
     """後方互換性のためのラッパー関数"""
     # デフォルトのモデルと設定を探す
     config_path = 'configs/load_saved_model.json'
-    model_dir = './saved_models'
+    model_dir = str(get_model_root())
     
     model_path = None
     if os.path.exists(model_dir):

--- a/src/gcn/algorithms/beamsearch_comparator.py
+++ b/src/gcn/algorithms/beamsearch_comparator.py
@@ -104,7 +104,7 @@ class BeamSearchComparator:
         batch_size = test_config.get('batch_size') or self.train_config.get('batch_size', 1)
         num_batches = test_config.get('num_batches', 5)
         
-        dataset = DatasetReader(num_test_data, batch_size, data_mode)
+        dataset = DatasetReader(num_test_data, batch_size, data_mode, self.train_config)
         batches_to_test = min(num_batches, dataset.max_iter)
         
         print(f"テストデータ: {data_mode}")

--- a/src/gcn/train/evaluator.py
+++ b/src/gcn/train/evaluator.py
@@ -22,7 +22,7 @@ class Evaluator:
         net.eval()
         num_data = getattr(self.config, f'num_{mode}_data')
         batch_size = self.config.batch_size
-        dataset = DatasetReader(num_data, batch_size, mode)
+        dataset = DatasetReader(num_data, batch_size, mode, self.config)
         batches_per_epoch = dataset.max_iter
         dataset = iter(dataset)
         edge_cw = None

--- a/src/gcn/train/trainer.py
+++ b/src/gcn/train/trainer.py
@@ -5,11 +5,13 @@ import numpy as np
 import os
 import hashlib
 import json
+from pathlib import Path
 from fastprogress import master_bar, progress_bar
 from sklearn.utils.class_weight import compute_class_weight
 
 from src.gcn.models.gcn_model import ResidualGatedGCNModel
 from src.common.data_management.dataset_reader import DatasetReader
+from src.common.config.paths import get_model_root
 from src.gcn.models.model_utils import edge_error, update_learning_rate
 from src.gcn.training.supervised_strategy import SupervisedLearningStrategy
 from src.gcn.training.reinforcement_strategy import ReinforcementLearningStrategy
@@ -22,7 +24,11 @@ class Trainer:
         self.config = config
         self.dtypeFloat = dtypeFloat
         self.dtypeLong = dtypeLong
-        self.models_dir = config.get('models_dir', './saved_models')
+        models_dir_cfg = config.get('models_dir')
+        if models_dir_cfg:
+            self.models_dir = str(Path(models_dir_cfg).expanduser())
+        else:
+            self.models_dir = str(get_model_root(config))
         self.net, self.optimizer = self._instantiate_model()
 
         # Initialize training strategy
@@ -101,7 +107,7 @@ class Trainer:
         num_data = self.config.get(f'num_{mode}_data')
         batch_size = self.config.batch_size
         accumulation_steps = self.config.accumulation_steps
-        dataset = DatasetReader(num_data, batch_size, mode)
+        dataset = DatasetReader(num_data, batch_size, mode, self.config)
 
         batches_per_epoch = dataset.max_iter
 

--- a/src/rl_ksp/environment/rl_environment.py
+++ b/src/rl_ksp/environment/rl_environment.py
@@ -13,6 +13,7 @@ import copy
 from typing import List, Tuple, Optional
 
 from src.common.graph.k_shortest_path import KShortestPathFinder
+from src.common.config.paths import get_graph_file, get_commodity_file
 
 
 class MinMaxLoadKSPsEnv(gym.core.Env):
@@ -307,11 +308,11 @@ class MinMaxLoadKSPsEnv(gym.core.Env):
             mode: データモード ('train', 'test', 'val')
         """
         # グラフファイルの読み込み（GCNモードと同じ形式）
-        graph_file = f"./data/{mode}_data/graph_file/{data_idx-(data_idx%10)}/graph_{data_idx}.gml"
+        graph_file = str(get_graph_file(mode, data_idx, self.config))
         self.G = nx.read_gml(graph_file, destringizer=int)
-        
+
         # 品種ファイルの読み込み（GCNモードと同じ形式）
-        commodity_file = f"./data/{mode}_data/commodity_file/{data_idx-(data_idx%10)}/commodity_data_{data_idx}.csv"
+        commodity_file = str(get_commodity_file(mode, data_idx, self.config))
         
         # デバッグ出力: RLがどのファイルを読み込んでいるか
         # print(f"    RL loading: graph={graph_file}, commodity={commodity_file}")

--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -21,6 +21,12 @@ from src.rl_ksp.models.dqn_model import DQNModel
 from src.common.data_management.dataset_reader import DatasetReader
 from src.gcn.train.metrics import MetricsLogger
 from src.common.data_management.exact_solution import SolveExactSolution
+from src.common.config.paths import (
+    get_model_root,
+    get_graph_file,
+    get_commodity_file,
+    get_exact_solution_file,
+)
 
 
 # DQNModel is now imported from src.rl_ksp.models.dqn_model
@@ -42,14 +48,18 @@ class RLTrainer:
         self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         
         # モデル保存設定
-        self.models_dir = Path(config.get('models_dir', './saved_models'))
-        self.models_dir.mkdir(exist_ok=True)
-        
+        models_dir_cfg = config.get('models_dir')
+        if models_dir_cfg:
+            self.models_dir = Path(models_dir_cfg).expanduser()
+        else:
+            self.models_dir = get_model_root(config)
+        self.models_dir.mkdir(parents=True, exist_ok=True)
+
         # データセットリーダーの初期化
         num_train_data = config.get('num_train_data', 100)
         batch_size = 1  # RL用には1つずつ処理
-        self.train_dataset = DatasetReader(num_train_data, batch_size, 'train')
-        self.test_dataset = DatasetReader(config.get('num_test_data', 20), batch_size, 'test')
+        self.train_dataset = DatasetReader(num_train_data, batch_size, 'train', config)
+        self.test_dataset = DatasetReader(config.get('num_test_data', 20), batch_size, 'test', config)
         
         # 環境の初期化（既存データを使用）
         self.env = MinMaxLoadKSPsEnv(config)
@@ -421,8 +431,8 @@ class RLTrainer:
             gt_load_factor = self._get_actual_load_factor(current_data_idx)
             
             # RLが実際に使用したファイルパスをデバッグ出力
-            graph_file = f"./data/test_data/graph_file/{current_data_idx-(current_data_idx%10)}/graph_{current_data_idx}.gml"
-            commodity_file = f"./data/test_data/commodity_file/{current_data_idx-(current_data_idx%10)}/commodity_data_{current_data_idx}.csv"
+            graph_file = str(get_graph_file('test', current_data_idx, self.config))
+            commodity_file = str(get_commodity_file('test', current_data_idx, self.config))
             # print(f"    RL actually used files: {graph_file}, {commodity_file}")
             
             # GCNと同じ計算方法: gt_load_factor / predicted_load_factor * 100
@@ -622,7 +632,7 @@ class RLTrainer:
         """
         # データセットリーダーを使用してバッチを取得（GCNと同じ方法）
         batch_size = 1
-        dataset = DatasetReader(self.config.get('num_test_data', 20), batch_size, 'test')
+        dataset = DatasetReader(self.config.get('num_test_data', 20), batch_size, 'test', self.config)
         
         # 指定されたdata_idxのデータを取得
         for i, batch in enumerate(dataset):
@@ -642,7 +652,7 @@ class RLTrainer:
         GCNの計算方法: gt_load_factor / predicted_load_factor * 100
         """
         try:
-            exact_solution_file = './data/test_data/exact_solution.csv'
+            exact_solution_file = str(get_exact_solution_file('test', self.config))
             
             with open(exact_solution_file, 'r') as f:
                 lines = f.readlines()

--- a/src/seq_flow_rl/training/trainer.py
+++ b/src/seq_flow_rl/training/trainer.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from ..models.seqflowrl_model import SeqFlowRLModel
 from .a2c_strategy import A2CStrategy
 from src.common.types import BatchData, validate_batch_types
+from src.common.config.paths import get_model_root
 
 
 class SeqFlowRLTrainer:
@@ -55,7 +56,11 @@ class SeqFlowRLTrainer:
         print(f"  - Learning rate: {config.get('learning_rate', 0.0005)}")
 
         # Checkpointing
-        self.checkpoint_dir = Path(config.get('checkpoint_dir', 'saved_models/seqflowrl/'))
+        checkpoint_dir_cfg = config.get('checkpoint_dir')
+        if checkpoint_dir_cfg:
+            self.checkpoint_dir = Path(checkpoint_dir_cfg).expanduser()
+        else:
+            self.checkpoint_dir = get_model_root(config) / 'seqflowrl'
         self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
         self.save_every = config.get('save_every', 5)
         self.save_best_only = config.get('save_best_only', True)


### PR DESCRIPTION
## 背景

データセットと学習済みモデルがリポジトリ内に混在しており、今後ファイル数が数万規模に拡大する見込み・複数PC間での実験運用を考えると構成上の負担が大きい。コードとデータを分離し、リポジトリ外（`../ml-data/graph-convnet-uelb/`）で管理する形に変更する。

## 変更内容

### 追加
- `src/common/config/paths.py`: データ/モデルのパス解決ヘルパー
  - 優先順位: 環境変数 (`GCN_UELB_DATA_ROOT` / `GCN_UELB_MODEL_ROOT`) → config の `data_root` / `model_root` → デフォルト (`<Projects>/ml-data/graph-convnet-uelb/`)
  - データセット名は config の `dataset_name` → `expt_name` にフォールバック
  - 提供関数: `get_data_root`, `get_model_root`, `get_dataset_dir`, `get_mode_dir`, `get_graph_file`, `get_commodity_file`, `get_node_flow_file`, `get_exact_solution_file`, `dataset_exists`

### コード更新 (パスヘルパー経由に統一)
- `src/common/data_management/` — `DatasetReader` に `config` 引数を追加、`create_data_files` / `dataset_manager` でハードコードパスを除去
- `src/gcn/train/` — `trainer` / `evaluator`
- `src/gcn/algorithms/` — `algorithm_examples` / `beamsearch_comparator`
- `src/rl_ksp/` — `environment/rl_environment` / `train/rl_trainer`
- `src/seq_flow_rl/training/trainer`
- `scripts/`: `generate_data`, `train_gcn`, `train_rl_ksp`, `train_seqflowrl`, `tune_hyperparameters`, `two_phase_training` の存在チェックを共通の `dataset_exists()` に統一

### Config クリーンアップ
- 18 個の JSON から不要になった `models_dir: "./saved_models"` と `checkpoint_dir: "saved_models/seqflowrl/"` を削除

## ディレクトリ構造

```
<Projects>/
├── graph-convnet-uelb/        # このリポジトリ
└── ml-data/graph-convnet-uelb/
    ├── datasets/
    │   └── {dataset_name}/
    │       ├── train_data/
    │       ├── val_data/
    │       └── test_data/
    └── saved_models/
```

## 移行手順 (他 PC でセットアップする場合)

```bash
# 1. デフォルト位置 (リポジトリと同階層の ml-data/graph-convnet-uelb) を使う場合
mkdir -p ../ml-data/graph-convnet-uelb/{datasets,saved_models}
# tar.zst を解凍 or データ生成

# 2. 任意の位置を使う場合は環境変数で指定
export GCN_UELB_DATA_ROOT=/path/to/datasets
export GCN_UELB_MODEL_ROOT=/path/to/saved_models
```

## Test plan
- [x] 全 17 ファイル `py_compile` 通過
- [x] `paths.py` の import と `get_data_root` / `get_model_root` の解決を確認
- [x] `configs/gcn/default2.json` で `dataset_exists()` が True を返すことを確認
- [x] `scripts/common/generate_data.py --help` 正常動作
- [ ] 実データで `generate_data.py` → `train_gcn.py` の一連の動作確認
- [ ] `train_rl_ksp.py` / `train_seqflowrl.py` の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)