### PR TITLE
fix: SeqFlowRL の approximation ratio 計算を修正し complete_rate を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,9 @@ A2C損失 = L_actor + 0.5 * L_critic + 0.01 * L_entropy
 | メトリクス | 定義 | 備考 |
 |---|---|---|
 | Load Factor | `max_edge(usage / capacity)` | 全エッジの最大負荷率。小さいほど良い |
-| Complete Rate | `(dst到達コモディティ数 / 全コモディティ数) × 100` | 全コモディティが目的地に到達した割合。100% が理想 |
-| Approximation Ratio | `mean(gt_load_factor_i / model_load_factor_i) × 100` | サンプル単位で最適解との比を取り平均。100% に近いほど良い。**全コモディティが dst に到達したサンプルのみ** で計算（不完全解は除外） |
+| Complete Rate (`Comp`) | `(dst到達コモディティ数 / 全コモディティ数) × 100` | コモディティ単位の到達率。100% が理想 |
+| Complete Sample Rate (`CompSample`) | `(全コモディティ到達サンプル数 / 全サンプル数) × 100` | サンプル単位の完全到達率。1サンプル内の全コモディティが dst に到達したサンプルの割合 |
+| Approximation Ratio | `mean(gt_load_factor_i / model_load_factor_i) × 100` | サンプル単位で最適解との比を取り平均。100% に近いほど良い。**CompSample の対象サンプルのみ** で計算（不完全解は除外） |
 | Reward | `2.0 - 2.0 * load_factor` | 連続報酬。容量超過時は追加ペナルティあり |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,15 @@ A2C損失 = L_actor + 0.5 * L_critic + 0.01 * L_entropy
 | `SeqFlowRLTrainer` | `training/trainer.py` | 学習ループ（epoch → batch → rollout → A2C更新） |
 | `MaskGenerator` | `utils/mask_utils.py` | 行動マスク（容量・ループ・訪問済み・到達可能性） |
 
+**評価メトリクス:**
+
+| メトリクス | 定義 | 備考 |
+|---|---|---|
+| Load Factor | `max_edge(usage / capacity)` | 全エッジの最大負荷率。小さいほど良い |
+| Complete Rate | `(dst到達コモディティ数 / 全コモディティ数) × 100` | 全コモディティが目的地に到達した割合。100% が理想 |
+| Approximation Ratio | `mean(gt_load_factor_i / model_load_factor_i) × 100` | サンプル単位で最適解との比を取り平均。100% に近いほど良い。**全コモディティが dst に到達したサンプルのみ** で計算（不完全解は除外） |
+| Reward | `2.0 - 2.0 * load_factor` | 連続報酬。容量超過時は追加ペナルティあり |
+
 ---
 
 ### 共通モジュール（`src/common/`）

--- a/analysis_reports/seqflowrl_approx_ratio_analysis.md
+++ b/analysis_reports/seqflowrl_approx_ratio_analysis.md
@@ -1,0 +1,202 @@
+# SeqFlowRL: Approximation Ratio が 100% を超える原因分析
+
+**作成日**: 2026-04-17
+**対象コード**: `src/seq_flow_rl/training/a2c_strategy.py`, `src/seq_flow_rl/algorithms/sequential_rollout.py`
+**観測例**: `Epoch 2/30 | Approx Ratio: 100.57%`
+
+---
+
+## 背景
+
+Approximation Ratio は「モデル解が最適解にどれだけ近いか」を表す指標で、**負荷率は小さいほど良い**ため、式は以下のように定義されている。
+
+```python
+# a2c_strategy.py:314
+approximation_ratio = (mean_gt_lf / mean_model_lf) * 100
+```
+
+コメント上の定義:
+- `100%` … モデル解が最適と一致
+- `< 100%` … 最適より悪い
+- `> 100%` … **理論上あり得ない**（最適解より良い解を見つけた）
+
+しかし実際には `100.57%` のようにわずかに 100% を超えるログが観測される。本ドキュメントではその原因を分析する。
+
+---
+
+## 結論（先に）
+
+主因は **モデル側の `mean_model_lf` が "真の負荷率" よりも過小に計算されていること** である。
+特に次の2点が効いている:
+
+1. **バグ**: `_update_edge_usage` が **src → 最初の中間ノードのエッジを edge_usage に積んでいない**（最も有力）
+2. **設計上の問題**: `mean_gt_lf / mean_model_lf` が「バッチ平均の比」であり、「サンプルごとの比の平均」ではないため、バッチ内分散が大きい場合に 100% をまたぐ偏りが出る
+
+---
+
+## 原因1: `_update_edge_usage` が先頭エッジを積んでいない（バグ）
+
+### 該当箇所
+
+**パス生成** (`sequential_rollout.py:208-269`):
+
+```python
+# L208-209: パス配列は空で初期化（src は入らない）
+paths = [[] for _ in range(batch_size)]
+
+# L215: current_nodes に src をセット
+current_nodes = src_nodes.clone()  # [B]
+
+# L268: サンプリング結果のみを path に追加
+for b in range(batch_size):
+    if not reached_dst[b]:
+        next_node = next_nodes[b].item()
+        paths[b].append(next_node)   # ← src は append されない
+```
+
+**需要量の積算** (`sequential_rollout.py:355-363`):
+
+```python
+for i in range(len(path) - 1):
+    u = path[i]
+    v = path[i + 1]
+    state['x_edges_usage'][b, u, v] += demand
+```
+
+### 何が起きているか
+
+コモディティ `c` の src = `s`、到達先 = `d`、サンプリングで `s → v1 → v2 → d` という経路が生成された場合:
+
+| 実際に使われるエッジ | `_update_edge_usage` で積まれる？ |
+|---|---|
+| `s → v1` | **× 抜け落ちる**（path に `s` が入っていない） |
+| `v1 → v2` | ○ |
+| `v2 → d` | ○ |
+
+→ **各コモディティにつき 1 エッジ分、需要が `edge_usage` に反映されない**。
+
+### 影響
+
+- `edge_usage` が過小評価される → `load_factor = max(edge_usage / capacity)` も過小評価
+- モデル側の `mean_model_lf` が下がり、`gt / model` の比が **100% を超えうる**
+- `max_edge_load` を更新していたエッジがたまたま先頭エッジだった場合、誤差がさらに拡大する
+
+### 修正案
+
+パスの起点を明示的に記録する:
+
+```python
+# sequential_rollout.py:208-209 近辺
+# src をパスの先頭に入れる
+paths = [[src_nodes[b].item()] for b in range(batch_size)]
+```
+
+または `_update_edge_usage` 側で `src` を別途考慮する。前者の方が既存コードへの影響が少ない。
+
+ただしこの修正は **train_step の報酬計算**・**approximation_ratio 計算** 両方に影響するため、挙動が変わる範囲を確認したうえで適用する必要がある。
+
+---
+
+## 原因2: 平均の取り方の偏り（設計上の問題）
+
+### 該当箇所 (`a2c_strategy.py:295-316`)
+
+```python
+if isinstance(gt_load_factors, torch.Tensor):
+    mean_gt_lf = gt_load_factors.mean().item()
+else:
+    mean_gt_lf = float(gt_load_factors.mean())
+
+mean_model_lf = load_factors.mean().item()
+
+if mean_model_lf > 0:
+    approximation_ratio = (mean_gt_lf / mean_model_lf) * 100
+```
+
+### 問題点
+
+これは **「バッチ平均の比」** である:
+
+```
+Approx = mean(gt) / mean(model)
+```
+
+本来必要なのは **「サンプルごとの比の平均」**:
+
+```
+Approx = mean(gt_i / model_i)
+```
+
+両者は一般に一致しない（Jensen の不等式、調和平均 vs 算術平均の関係）。
+
+### 具体例
+
+バッチに2サンプル、GT=[0.2, 0.6]、Model=[0.25, 0.4] の場合:
+
+| 指標 | 計算 | 値 |
+|---|---|---|
+| バッチ平均の比（現行） | 0.4 / 0.325 | **123%** |
+| サンプル毎の比の平均（正しい） | (0.2/0.25 + 0.6/0.4) / 2 | **115%** |
+
+特に **GT が低いサンプル（モデルが真似しにくい問題）が混ざる** と `mean_gt_lf` が GT の平均を超過的に引き上げ、100% を越えた値になりやすい。
+
+### 修正案
+
+```python
+# サンプルごとの比を計算してから平均
+valid = (load_factors > 0) & (gt_load_factors > 0)
+per_sample_ratio = (gt_load_factors[valid] / load_factors[valid]) * 100
+approximation_ratio = per_sample_ratio.mean().item()
+```
+
+---
+
+## 原因3: 不完全パス（未到達）の扱い
+
+`sequential_rollout.py:227-233` では `max_path_length` （seqflowrl_base.json: 20）到達で打ち切られるが、**未到達パスに対するペナルティは報酬側でのみ適用され**、`edge_usage` には「パスの到達したところまでの需要しか積まれない」。
+
+- 到達できなかったコモディティの需要 = 本来は全エッジに負荷がかかる可能性があった
+- しかし実装上は「途中まで歩いた分のエッジ」だけが負荷に加算される
+- → モデルの負荷率はさらに過小評価される
+
+学習序盤（Epoch 2時点）は到達率が低いため、この効果が顕著に出る。
+
+---
+
+## 原因4（補足）: 報酬側との二重カウント不在
+
+`_compute_rewards` では `load_factor` と `penalty` の両方を報酬に使うが、`_collect_metrics` の `load_factors` は **ペナルティ前の生の負荷率**。よって報酬の妥当性とは別に、approx ratio 計算は純粋な "model load factor vs gt load factor" の比較になっている点は正しい。
+
+一方で、GT はソルバーが **制約をすべて守って出した最適解** なので「到達失敗」や「容量超過」のような状態は含まない。モデル側が不完全解を出していても、`approximation_ratio` はそれを罰しない（load_factor にしか目を向けない）。→ **approx ratio は "パスの到達性" を反映しない指標** であり、これを単独で見ると誤った楽観的評価になる。
+
+---
+
+## 推奨対応
+
+### 短期（バグ修正）
+
+1. **原因1 の修正**: `paths` の初期化を `[[src_nodes[b].item()]]` に変更し、`_update_edge_usage` が先頭エッジも積むようにする
+2. 単体テストで「src → v1 → v2」のパスが `edge_usage[src, v1] += demand` を正しく行うか確認
+
+### 中期（指標の正確化）
+
+3. **原因2 の修正**: approximation_ratio をサンプル単位比の平均に変更
+4. **原因3 の対処**: `approximation_ratio` を計算する際、**dst に到達しなかったサンプルを除外**（または不完全パス比率を併記）
+5. ログに「Complete Rate」や「Invalid Solution Rate」を追加し、approx ratio 単独で評価しない
+
+### 長期（設計）
+
+6. approximation ratio の定義を「同一問題インスタンスでの比」に正規化
+7. バリデーション・テストでは、model が全制約を満たした場合のみ approx を計算するゲートを設ける
+
+---
+
+## 参考: 関連コード
+
+| 箇所 | 役割 |
+|---|---|
+| `src/seq_flow_rl/training/a2c_strategy.py:295-316` | approximation_ratio 計算（train） |
+| `src/seq_flow_rl/training/a2c_strategy.py:394-415` | approximation_ratio 計算（eval） |
+| `src/seq_flow_rl/algorithms/sequential_rollout.py:208-269` | パス生成（src を path に入れていない） |
+| `src/seq_flow_rl/algorithms/sequential_rollout.py:341-363` | edge_usage 更新（先頭エッジ抜け） |
+| `src/seq_flow_rl/training/a2c_strategy.py:176-200` | load_factor 計算 |

--- a/src/seq_flow_rl/algorithms/sequential_rollout.py
+++ b/src/seq_flow_rl/algorithms/sequential_rollout.py
@@ -205,8 +205,8 @@ class SequentialRolloutEngine:
         dst_nodes = state['x_commodities'][:, commodity_idx, 1].long()  # [B]
         demands = state['x_commodities'][:, commodity_idx, 2]  # [B]
 
-        # Initialize paths and log probabilities
-        paths = [[] for _ in range(batch_size)]
+        # Initialize paths with src node (needed for correct edge_usage tracking)
+        paths = [[src_nodes[b].item()] for b in range(batch_size)]
         log_probs = torch.zeros(batch_size, device=self.device)
         entropies_sum = torch.zeros(batch_size, device=self.device)
         num_steps = torch.zeros(batch_size, device=self.device)

--- a/src/seq_flow_rl/training/a2c_strategy.py
+++ b/src/seq_flow_rl/training/a2c_strategy.py
@@ -292,36 +292,42 @@ class A2CStrategy:
         else:
             load_factors = torch.zeros_like(rewards)
 
+        # Path quality metrics and completion check
+        path_lengths = []
+        x_commodities = batch_data['x_commodities'] if batch_data is not None else None
+        num_complete = 0
+        total_commodities = 0
+        complete_mask = torch.ones(len(paths), dtype=torch.bool, device=load_factors.device)
+
+        for b, batch_paths in enumerate(paths):
+            for c_idx, path in enumerate(batch_paths):
+                total_commodities += 1
+                path_lengths.append(len(path))
+                if x_commodities is not None:
+                    dst = int(x_commodities[b, c_idx, 1].item())
+                    if len(path) > 0 and path[-1] == dst:
+                        num_complete += 1
+                    else:
+                        complete_mask[b] = False
+
+        complete_rate = (num_complete / total_commodities * 100) if total_commodities > 0 else 0.0
+
         # Compute approximation ratio if ground truth is available
+        # Only count samples where all commodities reached destination and load_factor is feasible
         approximation_ratio = None
         if batch_data is not None and 'load_factor' in batch_data:
-            gt_load_factors = batch_data['load_factor']  # Ground truth from exact solution
-
-            # Handle device mismatch (gt might be on CPU, load_factors on GPU)
-            if isinstance(gt_load_factors, torch.Tensor):
-                mean_gt_lf = gt_load_factors.mean().item()
+            gt_load_factors = batch_data['load_factor']
+            if not isinstance(gt_load_factors, torch.Tensor):
+                gt_load_factors = torch.tensor(gt_load_factors, dtype=torch.float32, device=load_factors.device)
             else:
-                mean_gt_lf = float(gt_load_factors.mean())
+                gt_load_factors = gt_load_factors.to(load_factors.device)
 
-            mean_model_lf = load_factors.mean().item()
-
-            if mean_model_lf > 0:
-                # approximation_ratio = (gt / model) * 100
-                # 100% = same as optimal (perfect)
-                # < 100% = worse than optimal (lower is worse)
-                # > 100% = theoretically impossible (better than optimal)
-                # Since load factor is lower-is-better, gt/model gives correct ratio
-                approximation_ratio = (mean_gt_lf / mean_model_lf) * 100
+            valid = complete_mask & (load_factors > 1e-8) & (gt_load_factors > 0)
+            if valid.any():
+                per_sample_ratio = (gt_load_factors[valid] / load_factors[valid]) * 100
+                approximation_ratio = per_sample_ratio.mean().item()
             else:
-                approximation_ratio = 0.0
-
-        # Path quality metrics
-        path_lengths = []
-        completion_rates = []
-        for batch_paths in paths:
-            for path in batch_paths:
-                path_lengths.append(len(path))
-            # Completion rate would require dst info (skip for now)
+                approximation_ratio = None
 
         metrics = {
             # Losses
@@ -342,10 +348,11 @@ class A2CStrategy:
             'min_load_factor': load_factors.min().item(),
             'max_load_factor': load_factors.max().item(),
 
-            # Approximation ratio (if available)
+            # Approximation ratio (only for complete, feasible solutions)
             'approximation_ratio': approximation_ratio,
 
             # Path statistics
+            'complete_rate': complete_rate,
             'mean_path_length': np.mean(path_lengths) if path_lengths else 0.0,
             'max_path_length': np.max(path_lengths) if path_lengths else 0.0,
 
@@ -387,32 +394,39 @@ class A2CStrategy:
             # Collect metrics (no loss computation)
             paths = rollout_results['paths']
             path_lengths = []
-            for batch_paths in paths:
-                for path in batch_paths:
+            x_commodities = batch_data['x_commodities']
+            num_complete = 0
+            total_commodities = 0
+            complete_mask = torch.ones(len(paths), dtype=torch.bool, device=load_factors.device)
+
+            for b, batch_paths in enumerate(paths):
+                for c_idx, path in enumerate(batch_paths):
+                    total_commodities += 1
                     path_lengths.append(len(path))
+                    dst = int(x_commodities[b, c_idx, 1].item())
+                    if len(path) > 0 and path[-1] == dst:
+                        num_complete += 1
+                    else:
+                        complete_mask[b] = False
+
+            complete_rate = (num_complete / total_commodities * 100) if total_commodities > 0 else 0.0
 
             # Compute approximation ratio if ground truth is available
+            # Only count samples where all commodities reached destination
             approximation_ratio = None
             if 'load_factor' in batch_data:
-                gt_load_factors = batch_data['load_factor']  # Ground truth from exact solution
-
-                # Handle device mismatch (gt might be on CPU, load_factors on GPU)
-                if isinstance(gt_load_factors, torch.Tensor):
-                    mean_gt_lf = gt_load_factors.mean().item()
+                gt_load_factors = batch_data['load_factor']
+                if not isinstance(gt_load_factors, torch.Tensor):
+                    gt_load_factors = torch.tensor(gt_load_factors, dtype=torch.float32, device=load_factors.device)
                 else:
-                    mean_gt_lf = float(gt_load_factors.mean())
+                    gt_load_factors = gt_load_factors.to(load_factors.device)
 
-                mean_model_lf = load_factors.mean().item()
-
-                if mean_model_lf > 0:
-                    # approximation_ratio = (gt / model) * 100
-                    # 100% = same as optimal (perfect)
-                    # < 100% = worse than optimal (lower is worse)
-                    # > 100% = theoretically impossible (better than optimal)
-                    # Since load factor is lower-is-better, gt/model gives correct ratio
-                    approximation_ratio = (mean_gt_lf / mean_model_lf) * 100
+                valid = complete_mask & (load_factors > 1e-8) & (gt_load_factors > 0)
+                if valid.any():
+                    per_sample_ratio = (gt_load_factors[valid] / load_factors[valid]) * 100
+                    approximation_ratio = per_sample_ratio.mean().item()
                 else:
-                    approximation_ratio = 0.0
+                    approximation_ratio = None
 
             metrics = {
                 'mean_reward': rewards.mean().item(),
@@ -421,6 +435,7 @@ class A2CStrategy:
                 'max_load_factor': load_factors.max().item(),
                 'mean_path_length': np.mean(path_lengths) if path_lengths else 0.0,
                 'approximation_ratio': approximation_ratio,
+                'complete_rate': complete_rate,
             }
 
         return metrics

--- a/src/seq_flow_rl/training/a2c_strategy.py
+++ b/src/seq_flow_rl/training/a2c_strategy.py
@@ -274,9 +274,11 @@ class A2CStrategy:
         Collect training metrics.
 
         Metrics include:
-        - complete_rate: 全コモディティが dst に到達したコモディティの割合 (%)。
-          各バッチ内の全コモディティについて path[-1] == dst かを判定し、
-          (到達数 / 全コモディティ数) * 100 で算出。
+        - complete_rate: コモディティ単位の到達率 (%)。
+          (dst到達コモディティ数 / 全コモディティ数) * 100 で算出。
+        - complete_sample_rate: サンプル単位の完全到達率 (%)。
+          全コモディティが dst に到達したサンプルの割合。
+          (全コモディティ到達サンプル数 / 全サンプル数) * 100 で算出。
         - approximation_ratio: サンプル単位で (gt_lf / model_lf) * 100 を計算し平均。
           全コモディティが dst に到達したサンプルのみを対象とする（不完全解は除外）。
 
@@ -318,6 +320,7 @@ class A2CStrategy:
                         complete_mask[b] = False
 
         complete_rate = (num_complete / total_commodities * 100) if total_commodities > 0 else 0.0
+        complete_sample_rate = (complete_mask.sum().item() / len(paths) * 100) if len(paths) > 0 else 0.0
 
         # Compute approximation ratio if ground truth is available
         # Only count samples where all commodities reached destination and load_factor is feasible
@@ -360,6 +363,7 @@ class A2CStrategy:
 
             # Path statistics
             'complete_rate': complete_rate,
+            'complete_sample_rate': complete_sample_rate,
             'mean_path_length': np.mean(path_lengths) if path_lengths else 0.0,
             'max_path_length': np.max(path_lengths) if path_lengths else 0.0,
 
@@ -417,6 +421,7 @@ class A2CStrategy:
                         complete_mask[b] = False
 
             complete_rate = (num_complete / total_commodities * 100) if total_commodities > 0 else 0.0
+            complete_sample_rate = (complete_mask.sum().item() / len(paths) * 100) if len(paths) > 0 else 0.0
 
             # Compute approximation ratio if ground truth is available
             # Only count samples where all commodities reached destination
@@ -443,6 +448,7 @@ class A2CStrategy:
                 'mean_path_length': np.mean(path_lengths) if path_lengths else 0.0,
                 'approximation_ratio': approximation_ratio,
                 'complete_rate': complete_rate,
+                'complete_sample_rate': complete_sample_rate,
             }
 
         return metrics

--- a/src/seq_flow_rl/training/a2c_strategy.py
+++ b/src/seq_flow_rl/training/a2c_strategy.py
@@ -273,6 +273,13 @@ class A2CStrategy:
         """
         Collect training metrics.
 
+        Metrics include:
+        - complete_rate: 全コモディティが dst に到達したコモディティの割合 (%)。
+          各バッチ内の全コモディティについて path[-1] == dst かを判定し、
+          (到達数 / 全コモディティ数) * 100 で算出。
+        - approximation_ratio: サンプル単位で (gt_lf / model_lf) * 100 を計算し平均。
+          全コモディティが dst に到達したサンプルのみを対象とする（不完全解は除外）。
+
         Args:
             loss_components: Dictionary of loss components
             rewards: Rewards [B]

--- a/src/seq_flow_rl/training/trainer.py
+++ b/src/seq_flow_rl/training/trainer.py
@@ -80,10 +80,12 @@ class SeqFlowRLTrainer:
             'train_load_factor': [],
             'train_approx_ratio': [],
             'train_complete_rate': [],
+            'train_complete_sample_rate': [],
             'val_load_factor': [],
             'val_reward': [],
             'val_approx_ratio': [],
             'val_complete_rate': [],
+            'val_complete_sample_rate': [],
             'learning_rate': [],
             'epoch_times': [],
         }
@@ -285,6 +287,7 @@ class SeqFlowRLTrainer:
             'mean_entropy': [],
             'approximation_ratio': [],
             'complete_rate': [],
+            'complete_sample_rate': [],
         }
 
         # DatasetReader has max_iter attribute
@@ -359,6 +362,7 @@ class SeqFlowRLTrainer:
             'max_load_factor': [],
             'approximation_ratio': [],
             'complete_rate': [],
+            'complete_sample_rate': [],
         }
 
         # Create iterator from DatasetReader
@@ -407,8 +411,9 @@ class SeqFlowRLTrainer:
         """Log epoch summary."""
         print(f"\nEpoch {epoch + 1}/{self.config.get('max_epochs', 50)} | Time: {epoch_time:.2f}s | LR: {lr:.6f}")
 
-        # Training metrics with complete rate and approximation ratio
-        complete_str = f" | Complete: {train_metrics.get('complete_rate', 0):.1f}%"
+        # Training metrics with complete rates and approximation ratio
+        complete_str = (f" | Comp: {train_metrics.get('complete_rate', 0):.1f}%"
+                        f" | CompSample: {train_metrics.get('complete_sample_rate', 0):.1f}%")
         approx_ratio_str = ""
         if train_metrics.get('approximation_ratio') is not None:
             approx_ratio_str = f" | Approx: {train_metrics.get('approximation_ratio'):.2f}%"
@@ -418,9 +423,10 @@ class SeqFlowRLTrainer:
               f"LF: {train_metrics.get('mean_load_factor', 0):.4f}"
               f"{complete_str}{approx_ratio_str}")
 
-        # Validation metrics with complete rate and approximation ratio
+        # Validation metrics with complete rates and approximation ratio
         if val_metrics is not None:
-            val_complete_str = f" | Complete: {val_metrics.get('complete_rate', 0):.1f}%"
+            val_complete_str = (f" | Comp: {val_metrics.get('complete_rate', 0):.1f}%"
+                                f" | CompSample: {val_metrics.get('complete_sample_rate', 0):.1f}%")
             val_approx_str = ""
             if val_metrics.get('approximation_ratio') is not None:
                 val_approx_str = f" | Approx: {val_metrics.get('approximation_ratio'):.2f}%"
@@ -438,7 +444,8 @@ class SeqFlowRLTrainer:
               f"Loss: {metrics.get('total_loss', 0):.4f} | "
               f"Reward: {metrics.get('mean_reward', 0):.4f} | "
               f"LF: {metrics.get('mean_load_factor', 0):.4f} | "
-              f"Comp: {metrics.get('complete_rate', 0):.1f}%")
+              f"Comp: {metrics.get('complete_rate', 0):.1f}% | "
+              f"CompSample: {metrics.get('complete_sample_rate', 0):.1f}%")
 
     def _update_history(self, train_metrics, val_metrics, lr, epoch_time):
         """Update training history."""
@@ -447,6 +454,7 @@ class SeqFlowRLTrainer:
         self.training_history['train_load_factor'].append(train_metrics.get('mean_load_factor', 0))
         self.training_history['train_approx_ratio'].append(train_metrics.get('approximation_ratio', None))
         self.training_history['train_complete_rate'].append(train_metrics.get('complete_rate', 0))
+        self.training_history['train_complete_sample_rate'].append(train_metrics.get('complete_sample_rate', 0))
         self.training_history['learning_rate'].append(lr)
         self.training_history['epoch_times'].append(epoch_time)
 
@@ -455,6 +463,7 @@ class SeqFlowRLTrainer:
             self.training_history['val_reward'].append(val_metrics.get('mean_reward', 0))
             self.training_history['val_approx_ratio'].append(val_metrics.get('approximation_ratio', None))
             self.training_history['val_complete_rate'].append(val_metrics.get('complete_rate', 0))
+            self.training_history['val_complete_sample_rate'].append(val_metrics.get('complete_sample_rate', 0))
 
     def _save_checkpoint(self, epoch, train_metrics, val_metrics, is_best=False):
         """Save model checkpoint."""
@@ -543,8 +552,8 @@ class SeqFlowRLTrainer:
             f.write("=" * 50 + "\n")
             f.write("DETAILED EPOCH RESULTS\n")
             f.write("=" * 50 + "\n")
-            f.write(f"{'Epoch':<8}{'Loss':<12}{'Reward':<12}{'Load Factor':<14}{'Complete %':<12}{'Approx %':<12}{'Time (s)':<10}\n")
-            f.write("-" * 80 + "\n")
+            f.write(f"{'Epoch':<8}{'Loss':<12}{'Reward':<12}{'LF':<10}{'Comp %':<10}{'CompSmp %':<12}{'Approx %':<12}{'Time (s)':<10}\n")
+            f.write("-" * 84 + "\n")
 
             for i in range(len(self.training_history['train_loss'])):
                 epoch = i + 1
@@ -552,13 +561,14 @@ class SeqFlowRLTrainer:
                 reward = self.training_history['train_reward'][i]
                 lf = self.training_history['train_load_factor'][i]
                 comp = self.training_history['train_complete_rate'][i]
+                comp_smp = self.training_history['train_complete_sample_rate'][i]
                 approx = self.training_history['train_approx_ratio'][i]
                 epoch_time = self.training_history['epoch_times'][i]
 
                 approx_str = f"{approx:.2f}" if approx is not None else "N/A"
-                f.write(f"{epoch:<8}{loss:<12.4f}{reward:<12.4f}{lf:<14.4f}{comp:<12.1f}{approx_str:<12}{epoch_time:<10.2f}\n")
+                f.write(f"{epoch:<8}{loss:<12.4f}{reward:<12.4f}{lf:<10.4f}{comp:<10.1f}{comp_smp:<12.1f}{approx_str:<12}{epoch_time:<10.2f}\n")
 
-            f.write("-" * 80 + "\n")
+            f.write("-" * 84 + "\n")
             f.write("\n")
 
             # Summary statistics
@@ -566,7 +576,8 @@ class SeqFlowRLTrainer:
             f.write(f"  Mean Load Factor: {np.mean(self.training_history['train_load_factor']):.4f}\n")
             f.write(f"  Min Load Factor: {np.min(self.training_history['train_load_factor']):.4f}\n")
             f.write(f"  Max Load Factor: {np.max(self.training_history['train_load_factor']):.4f}\n")
-            f.write(f"  Mean Complete Rate: {np.mean(self.training_history['train_complete_rate']):.1f}%\n")
+            f.write(f"  Mean Complete Rate (commodity): {np.mean(self.training_history['train_complete_rate']):.1f}%\n")
+            f.write(f"  Mean Complete Sample Rate (sample): {np.mean(self.training_history['train_complete_sample_rate']):.1f}%\n")
 
             # Filter out None values for approximation ratio
             valid_approx = [x for x in self.training_history['train_approx_ratio'] if x is not None]

--- a/src/seq_flow_rl/training/trainer.py
+++ b/src/seq_flow_rl/training/trainer.py
@@ -79,9 +79,11 @@ class SeqFlowRLTrainer:
             'train_reward': [],
             'train_load_factor': [],
             'train_approx_ratio': [],
+            'train_complete_rate': [],
             'val_load_factor': [],
             'val_reward': [],
             'val_approx_ratio': [],
+            'val_complete_rate': [],
             'learning_rate': [],
             'epoch_times': [],
         }
@@ -282,6 +284,7 @@ class SeqFlowRLTrainer:
             'mean_load_factor': [],
             'mean_entropy': [],
             'approximation_ratio': [],
+            'complete_rate': [],
         }
 
         # DatasetReader has max_iter attribute
@@ -355,6 +358,7 @@ class SeqFlowRLTrainer:
             'min_load_factor': [],
             'max_load_factor': [],
             'approximation_ratio': [],
+            'complete_rate': [],
         }
 
         # Create iterator from DatasetReader
@@ -403,26 +407,28 @@ class SeqFlowRLTrainer:
         """Log epoch summary."""
         print(f"\nEpoch {epoch + 1}/{self.config.get('max_epochs', 50)} | Time: {epoch_time:.2f}s | LR: {lr:.6f}")
 
-        # Training metrics with approximation ratio
+        # Training metrics with complete rate and approximation ratio
+        complete_str = f" | Complete: {train_metrics.get('complete_rate', 0):.1f}%"
         approx_ratio_str = ""
         if train_metrics.get('approximation_ratio') is not None:
-            approx_ratio_str = f" | Approx Ratio: {train_metrics.get('approximation_ratio'):.2f}%"
+            approx_ratio_str = f" | Approx: {train_metrics.get('approximation_ratio'):.2f}%"
 
         print(f"  Train - Loss: {train_metrics.get('total_loss', 0):.4f} | "
               f"Reward: {train_metrics.get('mean_reward', 0):.4f} | "
-              f"Load Factor: {train_metrics.get('mean_load_factor', 0):.4f}"
-              f"{approx_ratio_str}")
+              f"LF: {train_metrics.get('mean_load_factor', 0):.4f}"
+              f"{complete_str}{approx_ratio_str}")
 
-        # Validation metrics with approximation ratio
+        # Validation metrics with complete rate and approximation ratio
         if val_metrics is not None:
+            val_complete_str = f" | Complete: {val_metrics.get('complete_rate', 0):.1f}%"
             val_approx_str = ""
             if val_metrics.get('approximation_ratio') is not None:
-                val_approx_str = f" | Approx Ratio: {val_metrics.get('approximation_ratio'):.2f}%"
+                val_approx_str = f" | Approx: {val_metrics.get('approximation_ratio'):.2f}%"
 
-            print(f"  Val   - Load Factor: {val_metrics.get('mean_load_factor', 0):.4f} "
+            print(f"  Val   - LF: {val_metrics.get('mean_load_factor', 0):.4f} "
                   f"(min: {val_metrics.get('min_load_factor', 0):.4f}, "
                   f"max: {val_metrics.get('max_load_factor', 0):.4f})"
-                  f"{val_approx_str}")
+                  f"{val_complete_str}{val_approx_str}")
         else:
             print(f"  Val   - Skipped (insufficient validation data)")
 
@@ -431,7 +437,8 @@ class SeqFlowRLTrainer:
         print(f"  [{epoch + 1}][{batch_idx + 1}/{num_batches}] "
               f"Loss: {metrics.get('total_loss', 0):.4f} | "
               f"Reward: {metrics.get('mean_reward', 0):.4f} | "
-              f"LF: {metrics.get('mean_load_factor', 0):.4f}")
+              f"LF: {metrics.get('mean_load_factor', 0):.4f} | "
+              f"Comp: {metrics.get('complete_rate', 0):.1f}%")
 
     def _update_history(self, train_metrics, val_metrics, lr, epoch_time):
         """Update training history."""
@@ -439,6 +446,7 @@ class SeqFlowRLTrainer:
         self.training_history['train_reward'].append(train_metrics.get('mean_reward', 0))
         self.training_history['train_load_factor'].append(train_metrics.get('mean_load_factor', 0))
         self.training_history['train_approx_ratio'].append(train_metrics.get('approximation_ratio', None))
+        self.training_history['train_complete_rate'].append(train_metrics.get('complete_rate', 0))
         self.training_history['learning_rate'].append(lr)
         self.training_history['epoch_times'].append(epoch_time)
 
@@ -446,6 +454,7 @@ class SeqFlowRLTrainer:
             self.training_history['val_load_factor'].append(val_metrics.get('mean_load_factor', 0))
             self.training_history['val_reward'].append(val_metrics.get('mean_reward', 0))
             self.training_history['val_approx_ratio'].append(val_metrics.get('approximation_ratio', None))
+            self.training_history['val_complete_rate'].append(val_metrics.get('complete_rate', 0))
 
     def _save_checkpoint(self, epoch, train_metrics, val_metrics, is_best=False):
         """Save model checkpoint."""
@@ -534,21 +543,22 @@ class SeqFlowRLTrainer:
             f.write("=" * 50 + "\n")
             f.write("DETAILED EPOCH RESULTS\n")
             f.write("=" * 50 + "\n")
-            f.write(f"{'Epoch':<8}{'Loss':<12}{'Reward':<12}{'Load Factor':<14}{'Approx %':<12}{'Time (s)':<10}\n")
-            f.write("-" * 68 + "\n")
+            f.write(f"{'Epoch':<8}{'Loss':<12}{'Reward':<12}{'Load Factor':<14}{'Complete %':<12}{'Approx %':<12}{'Time (s)':<10}\n")
+            f.write("-" * 80 + "\n")
 
             for i in range(len(self.training_history['train_loss'])):
                 epoch = i + 1
                 loss = self.training_history['train_loss'][i]
                 reward = self.training_history['train_reward'][i]
                 lf = self.training_history['train_load_factor'][i]
+                comp = self.training_history['train_complete_rate'][i]
                 approx = self.training_history['train_approx_ratio'][i]
                 epoch_time = self.training_history['epoch_times'][i]
 
                 approx_str = f"{approx:.2f}" if approx is not None else "N/A"
-                f.write(f"{epoch:<8}{loss:<12.4f}{reward:<12.4f}{lf:<14.4f}{approx_str:<12}{epoch_time:<10.2f}\n")
+                f.write(f"{epoch:<8}{loss:<12.4f}{reward:<12.4f}{lf:<14.4f}{comp:<12.1f}{approx_str:<12}{epoch_time:<10.2f}\n")
 
-            f.write("-" * 68 + "\n")
+            f.write("-" * 80 + "\n")
             f.write("\n")
 
             # Summary statistics
@@ -556,6 +566,7 @@ class SeqFlowRLTrainer:
             f.write(f"  Mean Load Factor: {np.mean(self.training_history['train_load_factor']):.4f}\n")
             f.write(f"  Min Load Factor: {np.min(self.training_history['train_load_factor']):.4f}\n")
             f.write(f"  Max Load Factor: {np.max(self.training_history['train_load_factor']):.4f}\n")
+            f.write(f"  Mean Complete Rate: {np.mean(self.training_history['train_complete_rate']):.1f}%\n")
 
             # Filter out None values for approximation ratio
             valid_approx = [x for x in self.training_history['train_approx_ratio'] if x is not None]


### PR DESCRIPTION
## Summary

- SeqFlowRL の approximation ratio が 100% を超える問題を修正
- パス品質の観測性向上のため `complete_rate` メトリクスを追加

## 変更内容

### バグ修正: 先頭エッジの edge_usage 抜け
- `sequential_rollout.py`: `paths` の初期化を `[[]]` → `[[src]]` に変更
- これにより `_update_edge_usage` が `src → 最初の中間ノード` のエッジも需要を積むようになる
- **影響**: load_factor が正確に計算され、報酬シグナルも改善される

### 指標改善: approximation ratio の計算方法変更
- `a2c_strategy.py`: `mean(gt) / mean(model)` → `mean(gt_i / model_i)` に変更（サンプル単位の比の平均）
- dst に到達しなかったサンプルを approx ratio 計算から除外
- train/eval 両方の `_collect_metrics` / `eval_step` に適用

### 観測性向上: complete_rate の追加
- `a2c_strategy.py`: 全コモディティが dst に到達したかを計算し `complete_rate` として返却
- `trainer.py`: `training_history`、epoch ログ、batch ログ、ファイルログすべてに `complete_rate` を追加
- ログ表示例: `Train - Loss: 0.43 | Reward: 1.72 | LF: 0.152 | Complete: 94.3% | Approx: 87.2%`

## 分析ドキュメント
- `analysis_reports/seqflowrl_approx_ratio_analysis.md` に原因分析と修正方針を記載

## Test plan
- [ ] `python scripts/seq_flow_rl/train_seqflowrl.py --config configs/seqflowrl/seqflowrl_base.json` で学習を実行し、approx ratio が 100% を超えないことを確認
- [ ] ログに `Complete: XX.X%` が正しく表示されることを確認
- [ ] 学習ログファイル (`logs/seqflowrl_training_*.txt`) に complete_rate カラムが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)