### PR TITLE
feat: RL-KSP テスト時のフェーズ別時間計測を追加

### DIFF
--- a/src/rl_ksp/environment/rl_environment.py
+++ b/src/rl_ksp/environment/rl_environment.py
@@ -10,7 +10,8 @@ import numpy as np
 import random
 import csv
 import copy
-from typing import List, Tuple, Optional
+import time
+from typing import List, Tuple, Optional, Dict
 
 from src.common.graph.k_shortest_path import KShortestPathFinder
 from src.common.config.paths import get_graph_file, get_commodity_file
@@ -246,12 +247,17 @@ class MinMaxLoadKSPsEnv(gym.core.Env):
     def reset(self, mode: str = 'train') -> List[float]:
         """エピソードの初期化"""
         self.time = 0
+        self.phase_times: Dict[str, float] = {}
         # 毎エピソードで新しいグラフ・品種を生成
         self.grouping = self.get_random_grouping(mode)
         self.pair_list = self.get_pair_list()
+
+        t0 = time.perf_counter()
         self.observation = self.get_observation()
+        self.phase_times['initial_observation'] = time.perf_counter() - t0
+
         count = 0
-        
+
         # 初期状態から全ての行動のエントリーが一つも存在しない場合
         while all(val == -100.0 for val in self.observation):
             combination = self.search_random_combination(self.allcommodity_ksps)
@@ -260,42 +266,45 @@ class MinMaxLoadKSPsEnv(gym.core.Env):
             self.observation = self.get_observation()
             if count == self.count_limit:
                 break
-        
+
         return self.observation
     
     def get_random_grouping(self, mode: str = 'train') -> List[List[int]]:
         """状態の初期化 - 既存データを使用"""
         # 現在のdata_idxを保存（このデータを実際に使用する）
         self.current_used_data_idx = self.data_idx
-        
-        # 既存データを使用（GCNモードと同じデータ範囲）
+
+        # データ読込み
+        t0 = time.perf_counter()
         self.load_data_from_files(self.data_idx, mode)
-        
+        self.phase_times['data_loading'] = time.perf_counter() - t0
+
         # データインデックスの循環処理
         if mode == 'train':
-            # トレーニング時：設定のnum_train_dataを使用して循環
             self.data_idx = (self.data_idx + 1) % self.max_train_data
         elif mode == 'test':
-            # テスト時：設定のnum_test_dataを使用して循環
             max_test_data = self.config.get('num_test_data', 20)
             self.data_idx = (self.data_idx + 1) % max_test_data
         else:
-            # その他（val等）：デフォルトでtrainと同じ
             self.data_idx = (self.data_idx + 1) % self.max_train_data
-        
+
         # K最短経路探索
+        t0 = time.perf_counter()
         self.allcommodity_ksps = self.ksp_finder.search_k_shortest_paths(
             self.G, self.commodity_list, self.K
         )
-        
-        # 初期状態の設定
+        self.phase_times['k_shortest_paths'] = time.perf_counter() - t0
+
+        # 初期解生成
+        t0 = time.perf_counter()
         if self.initial_state == 1:
             combination = self.search_combination(self.allcommodity_ksps)
         elif self.initial_state == 2:
             combination = self.search_random_combination(self.allcommodity_ksps)
         else:
             combination = self.search_combination(self.allcommodity_ksps)
-        
+        self.phase_times['initial_solution'] = time.perf_counter() - t0
+
         self.grouping = combination[0]
         return self.grouping
     

--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -397,32 +397,51 @@ class RLTrainer:
     def test(self, test_episodes: int = 100) -> None:
         """
         テストの実行
-        
+
         Args:
             test_episodes: テストエピソード数
         """
         print(f"Starting RL testing for {test_episodes} episodes")
-        
+
         test_results = []
         total_test_time = 0.0
-        
+        # フェーズ別累積時間
+        phase_totals = {
+            'data_loading': 0.0,
+            'k_shortest_paths': 0.0,
+            'initial_solution': 0.0,
+            'initial_observation': 0.0,
+            'dqn_inference': 0.0,
+            'env_step': 0.0,
+        }
+
         for episode in range(test_episodes):
             start_time = time.time()
             state = self.env.reset('test')  # テストモードを指定
+            # reset 内のフェーズ時間を集計
+            for key in ('data_loading', 'k_shortest_paths', 'initial_solution', 'initial_observation'):
+                phase_totals[key] += self.env.phase_times.get(key, 0.0)
+
             state = np.reshape(state, [1, self.env.observation_space.shape[0]])
             done = False
             total_reward = 0.0
             steps = 0
-            
+
             while not done:
+                t_inf = time.perf_counter()
                 action = self.choose_action(state[0])
+                phase_totals['dqn_inference'] += time.perf_counter() - t_inf
+
+                t_step = time.perf_counter()
                 next_state, reward, done, _, max_load = self.env.step(action)
+                phase_totals['env_step'] += time.perf_counter() - t_step
+
                 next_state = np.reshape(next_state, [1, self.env.observation_space.shape[0]])
-                
+
                 total_reward += reward
                 steps += 1
                 state = next_state
-            
+
             episode_time = time.time() - start_time
             total_test_time += episode_time
             
@@ -493,6 +512,20 @@ class RLTrainer:
         print(f"Average Steps per Episode: {avg_steps:.2f}")
         print(f"Average Time per Episode: {avg_time:.4f}s")
         print(f"Total Test Time: {total_test_time:.2f}s")
+        print(f"="*50)
+
+        # フェーズ別時間の表示
+        print(f"\n" + "="*50)
+        print(f"PHASE TIMING BREAKDOWN ({test_episodes} episodes)")
+        print(f"="*50)
+        for phase, total_sec in phase_totals.items():
+            avg_ms = total_sec / test_episodes * 1000
+            pct = total_sec / total_test_time * 100 if total_test_time > 0 else 0.0
+            print(f"  {phase:<25s}: {total_sec:8.3f}s total, {avg_ms:8.2f}ms/ep, {pct:5.1f}%")
+        accounted = sum(phase_totals.values())
+        other = total_test_time - accounted
+        print(f"  {'other':<25s}: {other:8.3f}s total")
+        print(f"  {'TOTAL':<25s}: {total_test_time:8.3f}s")
         print(f"="*50)
     
     def _save_training_history(self, history: List[Dict]) -> None:


### PR DESCRIPTION
## Summary
- RL-KSP のテスト実行時に各フェーズ（データ読込み、K最短パス生成、初期解生成、観測値計算、DQN推論、環境ステップ）の所要時間を計測・表示する機能を追加
- テスト完了後にフェーズ別の累積時間・平均時間・割合をサマリー表示

## 変更内容
- `rl_environment.py`: `reset()` / `get_random_grouping()` 内の各フェーズに `time.perf_counter()` による計測を追加し、`phase_times` dictに記録
- `rl_trainer.py`: `test()` メソッドでDQN推論・env.step の計測を追加し、全フェーズの集計結果を `PHASE TIMING BREAKDOWN` として表示

## Test plan
- [ ] RL-KSP テストを実行し、フェーズ別時間が正しく表示されることを確認
- [ ] 既存の学習・テスト結果に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)