### PR TITLE
fix: 到達不能コモディティでフェイルファストするように修正

### DIFF
--- a/src/gnn_ils/environment/ils_environment.py
+++ b/src/gnn_ils/environment/ils_environment.py
@@ -105,16 +105,20 @@ class ILSEnvironment:
         return self._build_state()
 
     def _compute_initial_assignment(self) -> List[List[int]]:
-        """Dijkstra で初期パス割当 (容量無視)。全コモディティ到達を保証する。"""
+        """
+        Dijkstra で初期パス割当 (容量無視)。全コモディティ到達を保証する。
+
+        Note: build_path_pool() で到達不能コモディティは既に ValueError になるため、
+        ここでの Dijkstra 失敗はパスプールの先頭パスで代替する。
+        """
         assignment = []
-        for commodity in self.commodity_list:
+        for c_idx, commodity in enumerate(self.commodity_list):
             src, dst = int(commodity[0]), int(commodity[1])
             try:
                 path = list(nx.dijkstra_path(self.G, src, dst, weight='weight'))
             except (nx.NetworkXNoPath, nx.NodeNotFound):
-                # パスが存在しない場合はパスプールの先頭を使用
-                pool = self.path_pool[len(assignment)] if len(assignment) < len(self.path_pool) else []
-                path = pool[0] if pool else [src]
+                # build_path_pool() で到達保証済みなのでパスプール先頭を使用
+                path = self.path_pool[c_idx][0]
             assignment.append(path)
         return assignment
 

--- a/src/gnn_ils/environment/path_pool_manager.py
+++ b/src/gnn_ils/environment/path_pool_manager.py
@@ -54,7 +54,13 @@ class PathPoolManager:
                     fallback = nx.dijkstra_path(G, src, dst, weight='weight')
                     merged = [list(fallback)]
                 except (nx.NetworkXNoPath, nx.NodeNotFound):
-                    merged = [[src]]
+                    raise ValueError(
+                        f"FATAL ERROR: No path found for commodity "
+                        f"(source={src}, target={dst}). "
+                        f"GNN-ILS requires all commodities to be reachable "
+                        f"to guarantee 100% completion rate. "
+                        f"Graph may be disconnected or missing reverse edges."
+                    )
 
             path_pool.append(merged)
 


### PR DESCRIPTION
## Summary
- `build_path_pool()` で到達不能コモディティ検出時に `ValueError` で即座に停止するフェイルファスト方式に変更
- 従来の `[[src]]` (始点のみの偽パス) フォールバックを削除 — 到達率100%保証が静かに壊れる原因だった
- `_compute_initial_assignment()` のフォールバックもパスプール先頭を使うように簡素化

## 背景
従来の動作では到達不能な (src, dst) ペアがあった場合:
1. `[[src]]` が返され、dst に到達しない偽パスがプールに入る
2. `commodity_mask` で永久にマスクされ修復不能
3. 需要がエッジに載らず `load_factor` が過小評価される
4. エラーもログも出ないため検出困難

既存の RL-KSP (`rl_environment.py:92`) では同じ状況で `ValueError` を投げており、それと一貫した方式に統一。

## Test plan
- [ ] 正常データ (連結グラフ) で `train_gnn_ils.py` が問題なく動作すること
- [ ] 非連結グラフを入力した場合に `ValueError` が発生し明確なエラーメッセージが出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)