### PR TITLE
feat: ILS best-so-far トラッキングとログ記録

### DIFF
--- a/src/gnn_ils/environment/ils_environment.py
+++ b/src/gnn_ils/environment/ils_environment.py
@@ -60,6 +60,11 @@ class ILSEnvironment:
         self.no_improve_count: int = 0
         self.capacity_np: Optional[np.ndarray] = None
 
+        # Best-so-far トラッキング
+        self.best_load_factor: float = float('inf')
+        self.best_assignment: List[List[int]] = []
+        self.best_iteration: int = 0
+
     def reset(
         self,
         G: nx.Graph,
@@ -101,6 +106,11 @@ class ILSEnvironment:
         # カウンタ初期化
         self.iteration = 0
         self.no_improve_count = 0
+
+        # Best-so-far を初期状態で初期化
+        self.best_load_factor = self.current_load_factor
+        self.best_assignment = [list(p) for p in self.current_assignment]
+        self.best_iteration = 0
 
         return self._build_state()
 
@@ -165,6 +175,12 @@ class ILSEnvironment:
         else:
             self.no_improve_count += 1
 
+        # Best-so-far 更新
+        if new_load_factor < self.best_load_factor - 1e-8:
+            self.best_load_factor = new_load_factor
+            self.best_assignment = [list(p) for p in self.current_assignment]
+            self.best_iteration = self.iteration
+
         reward = self._compute_reward(old_load_factor, new_load_factor)
         done = self._check_done()
 
@@ -224,6 +240,14 @@ class ILSEnvironment:
         mask = torch.zeros(1, self.max_candidate_paths, dtype=torch.bool)
         mask[0, :num_valid] = True
         return mask
+
+    def get_best_solution(self) -> Dict:
+        """エピソード中の best-so-far 解を返す。"""
+        return {
+            'best_load_factor': self.best_load_factor,
+            'best_assignment': self.best_assignment,
+            'best_iteration': self.best_iteration,
+        }
 
     def _build_state(self) -> Dict:
         """現在の状態辞書を構築する。"""

--- a/src/gnn_ils/training/ils_a2c_strategy.py
+++ b/src/gnn_ils/training/ils_a2c_strategy.py
@@ -100,6 +100,7 @@ class ILSA2CStrategy:
             'initial_load_factor': init_lf,
             'improvement': improvement,
             'num_iterations': len(trajectory['rewards']),
+            'best_iteration': trajectory['best_iteration'],
         }
         return metrics
 
@@ -182,6 +183,12 @@ class ILSA2CStrategy:
             state = new_state
 
         trajectory['final_load_factor'] = state['load_factor']
+
+        # Best-so-far 情報を追加
+        best_solution = self.env.get_best_solution()
+        trajectory['best_load_factor'] = best_solution['best_load_factor']
+        trajectory['best_iteration'] = best_solution['best_iteration']
+
         return trajectory
 
     def _compute_a2c_loss(
@@ -261,22 +268,24 @@ class ILSA2CStrategy:
             trajectory = self._run_ils_episode(batch_data, deterministic=True)
 
         init_lf = trajectory['initial_load_factor']
-        final_lf = trajectory['final_load_factor']
+        best_lf = trajectory['best_load_factor']
+        best_iter = trajectory['best_iteration']
         improvement = 0.0
         if init_lf > 1e-8:
-            improvement = (init_lf - final_lf) / init_lf * 100.0
+            improvement = (init_lf - best_lf) / init_lf * 100.0
 
-        # Approximation ratio (グラウンドトゥルースと比較)
+        # Approximation ratio (グラウンドトゥルースと比較、best-so-far を使用)
         approximation_ratio = None
         gt_lf = batch_data.get('load_factor_scalar')
-        if gt_lf is not None and gt_lf > 1e-8 and final_lf > 1e-8:
-            approximation_ratio = (gt_lf / final_lf) * 100.0
+        if gt_lf is not None and gt_lf > 1e-8 and best_lf > 1e-8:
+            approximation_ratio = (gt_lf / best_lf) * 100.0
 
         return {
-            'final_load_factor': final_lf,
+            'final_load_factor': best_lf,
             'initial_load_factor': init_lf,
             'improvement': improvement,
             'num_iterations': len(trajectory['rewards']),
+            'best_iteration': best_iter,
             'complete_rate': 100.0,   # パスプール構造的保証
             'approximation_ratio': approximation_ratio,
         }

--- a/src/gnn_ils/training/trainer.py
+++ b/src/gnn_ils/training/trainer.py
@@ -63,10 +63,12 @@ class GNNILSTrainer:
             'train_improvement': [],
             'train_num_iterations': [],
             'train_approx_ratio': [],
+            'train_best_iteration': [],
             'val_load_factor': [],
             'val_improvement': [],
             'val_num_iterations': [],
             'val_approx_ratio': [],
+            'val_best_iteration': [],
             'learning_rate': [],
             'epoch_times': [],
         }
@@ -228,6 +230,7 @@ class GNNILSTrainer:
             'improvement': [],
             'num_iterations': [],
             'approximation_ratio': [],
+            'best_iteration': [],
         }
 
         dataset_iter = iter(train_loader)
@@ -288,6 +291,7 @@ class GNNILSTrainer:
             'improvement': [],
             'num_iterations': [],
             'approximation_ratio': [],
+            'best_iteration': [],
         }
 
         dataset_iter = iter(val_loader)
@@ -339,7 +343,8 @@ class GNNILSTrainer:
         print(f"  Train - Loss: {train_metrics.get('total_loss', 0):.4f} | "
               f"LF: {train_metrics.get('mean_load_factor', 0):.4f} | "
               f"Improve: {train_metrics.get('improvement', 0):.1f}% | "
-              f"Iters: {train_metrics.get('num_iterations', 0):.1f}"
+              f"Iters: {train_metrics.get('num_iterations', 0):.1f} | "
+              f"BestIter: {train_metrics.get('best_iteration', 0):.1f}"
               f"{approx_str}")
 
         if val_metrics is not None:
@@ -348,7 +353,8 @@ class GNNILSTrainer:
                 val_approx_str = f" | Approx: {val_metrics['approximation_ratio']:.2f}%"
             print(f"  Val   - LF: {val_metrics.get('mean_load_factor', 0):.4f} | "
                   f"Improve: {val_metrics.get('improvement', 0):.1f}% | "
-                  f"Iters: {val_metrics.get('num_iterations', 0):.1f}"
+                  f"Iters: {val_metrics.get('num_iterations', 0):.1f} | "
+                  f"BestIter: {val_metrics.get('best_iteration', 0):.1f}"
                   f"{val_approx_str}")
 
     def _update_history(self, train_metrics, val_metrics, lr, epoch_time):
@@ -358,6 +364,7 @@ class GNNILSTrainer:
         self.training_history['train_improvement'].append(train_metrics.get('improvement', 0.0))
         self.training_history['train_num_iterations'].append(train_metrics.get('num_iterations', 0.0))
         self.training_history['train_approx_ratio'].append(train_metrics.get('approximation_ratio'))
+        self.training_history['train_best_iteration'].append(train_metrics.get('best_iteration', 0.0))
         self.training_history['learning_rate'].append(lr)
         self.training_history['epoch_times'].append(epoch_time)
 
@@ -366,6 +373,7 @@ class GNNILSTrainer:
             self.training_history['val_improvement'].append(val_metrics.get('improvement', 0.0))
             self.training_history['val_num_iterations'].append(val_metrics.get('num_iterations', 0.0))
             self.training_history['val_approx_ratio'].append(val_metrics.get('approximation_ratio'))
+            self.training_history['val_best_iteration'].append(val_metrics.get('best_iteration', 0.0))
 
     def _save_checkpoint(self, epoch, train_metrics, val_metrics, is_best=False):
         config_dict = dict(self.config) if hasattr(self.config, 'items') else self.config


### PR DESCRIPTION
## Summary
- ILSEnvironment に best-so-far トラッキングを追加（`best_load_factor`, `best_assignment`, `best_iteration`）
- テスト時（`eval_step`）は最終解ではなく best-so-far を返すことで、探索中の解悪化を防止
- 何ステップ目が最良解だったかをエポック平均でログ出力（`BestIter`）

## Changes
- `ils_environment.py`: `reset()`/`step()` で best 解を追跡、`get_best_solution()` メソッド追加
- `ils_a2c_strategy.py`: trajectory に best 情報を含め、`eval_step` で best_load_factor を使用
- `trainer.py`: training_history と epoch ログに `best_iteration` を追加

## Test plan
- [ ] 学習を実行し、BestIter がログに表示されることを確認
- [ ] best_iteration < num_iterations となるケースで、final_load_factor が悪化しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)