### PR TITLE
fix: GNN-ILS エントロピー調整・NSFNet config追加・RL-KSP GT読み取りバグ修正

### DIFF
--- a/configs/gnn_ils/gnn_ils_nsfnet.json
+++ b/configs/gnn_ils/gnn_ils_nsfnet.json
@@ -1,6 +1,6 @@
 {
-    "_comment_meta": "=== GNN-ILS: GNN-guided Iterated Local Search ===",
-    "expt_name": "gnn_ils_base",
+    "_comment_meta": "=== GNN-ILS: GNN-guided Iterated Local Search (NSFNet) ===",
+    "expt_name": "gnn_ils_nsfnet",
     "gpu_id": "0",
     "use_gpu": false,
 
@@ -8,15 +8,15 @@
     "solver_type": "pulp",
     "solver_time_limit": 60,
     "require_optimal": true,
-    "graph_model": "random",
+    "graph_model": "nsfnet",
     "num_train_data": 3200,
     "num_val_data": 320,
     "num_test_data": 320,
     "num_nodes": 14,
     "num_commodities": 5,
     "sample_size": 5,
-    "capacity_lower": 1000,
-    "capacity_higher": 10000,
+    "capacity_lower": 500,
+    "capacity_higher": 2500,
     "demand_lower": 5,
     "demand_higher": 500,
 
@@ -53,7 +53,7 @@
     "reward_mode": "shared",
 
     "_comment_training": "=== Training Configuration ===",
-    "max_epochs": 50,
+    "max_epochs": 10,
     "val_every": 5,
     "batch_size": 1,
     "_batch_size_note": "ILS は1サンプルずつ改善ループを回す",

--- a/src/common/graph/k_shortest_path.py
+++ b/src/common/graph/k_shortest_path.py
@@ -70,7 +70,7 @@ class KShortestPathFinder:
                     break
                     
             # K本の経路が見つからない場合は、見つかった分だけ返す
-            if len(ksps_list) < K:
+            if len(ksps_list) <= 1:
                 print(f"Warning: Only {len(ksps_list)} paths found for source {source} to target {target}")
                 
             return ksps_list

--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -699,7 +699,7 @@ class RLTrainer:
         """
         # データセットリーダーを使用してバッチを取得（GCNと同じ方法）
         batch_size = 1
-        dataset = DatasetReader(self.config.get('num_test_data', 20), batch_size, 'test', self.config)
+        dataset = DatasetReader(self.config.get('num_test_data', 20), batch_size, 'test', self.config, shuffle=False)
         
         # 指定されたdata_idxのデータを取得
         for i, batch in enumerate(dataset):


### PR DESCRIPTION
## Summary

- **GNN-ILS `gnn_ils_base.json`**: `entropy_weight_l1` 0.02→0.005、`entropy_weight_l2` 0.01→0.003 に削減。探索ノイズを抑えて ILS の改善率を安定化
- **GNN-ILS `gnn_ils_nsfnet.json`**: NSFNet 固定トポロジー用の新規 config を追加。RL-KSP との公平な比較のため `capacity_lower/higher=500/2500`、`max_epochs=10` に設定
- **`k_shortest_path.py`**: パス不足の Warning を 0〜1 本のみに絞り、学習中の出力ノイズを削減
- **`rl_trainer.py`**: `_get_actual_load_factor` で `DatasetReader` に `shuffle=False` を指定。PR #47 のシャッフル導入後に GT とテストサンプルが不一致になるバグを修正

## Test plan

- [ ] GNN-ILS (random): `python scripts/gnn_ils/train_gnn_ils.py --config configs/gnn_ils/gnn_ils_base.json`
- [ ] GNN-ILS (nsfnet): データ生成後に `python scripts/gnn_ils/train_gnn_ils.py --config configs/gnn_ils/gnn_ils_nsfnet.json`
- [ ] RL-KSP テスト: `python scripts/rl_ksp/test_rl_ksp.py` で Approximation Rate が 100% を超えないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)