### PR TITLE
fix: GNN-ILS学習安定化のためのハイパーパラメータ調整

### DIFF
--- a/configs/gnn_ils/gnn_ils_base.json
+++ b/configs/gnn_ils/gnn_ils_base.json
@@ -30,7 +30,7 @@
     "commodity_selector_mlp_layers": 2,
     "path_selector_mlp_layers": 2,
     "value_head_mlp_layers": 3,
-    "use_graph_embedding_value": false,
+    "use_graph_embedding_value": true,
 
     "_comment_path_pool": "=== Path Pool Configuration ===",
     "K": 10,
@@ -47,10 +47,11 @@
     "entropy_weight_l2": 0.003,
     "_entropy_note": "L1 (C択) は探索空間が小さいため大きめ、L2 (パス択) は小さめ",
     "value_loss_weight": 0.5,
-    "gamma": 0.99,
+    "gamma": 0.95,
     "normalize_advantages": true,
     "grad_clip_norm": 1.0,
     "reward_mode": "shared",
+    "reward_scale": 100.0,
 
     "_comment_training": "=== Training Configuration ===",
     "max_epochs": 50,

--- a/src/gnn_ils/environment/ils_environment.py
+++ b/src/gnn_ils/environment/ils_environment.py
@@ -43,6 +43,7 @@ class ILSEnvironment:
         self.perturbation_prob = config.get('perturbation_prob', 0.1)
         self.max_candidate_paths = config.get('max_candidate_paths', 15)
         self.reward_mode = config.get('reward_mode', 'shared')
+        self.reward_scale = config.get('reward_scale', 100.0)
 
         self.path_pool_manager = PathPoolManager(config)
 
@@ -197,9 +198,9 @@ class ILSEnvironment:
         """
         報酬計算: 改善時は正、悪化時は負。
 
-        shared モード: reward = -(new_lf - old_lf)
+        shared モード: reward = -(new_lf - old_lf) * reward_scale
         """
-        return -(new_load_factor - old_load_factor)
+        return -(new_load_factor - old_load_factor) * self.reward_scale
 
     def _check_done(self) -> bool:
         """終了条件: max_iterations 到達 or no_improve_patience 超過。"""


### PR DESCRIPTION
## Summary
- Value Headの入力を`use_graph_embedding_value=true`に変更（入力次元 8960→128）で初期Loss爆発を抑制
- 報酬スケーリング（`reward_scale=100.0`）を追加し、`1e-2`オーダーの微小な報酬を`1e0`オーダーに引き上げ
- `gamma`を`0.99→0.95`に変更し、50ステップILSループで近い将来の改善を重視

## Background
GNN-ILSの近似率が65%程度に留まっている問題の分析結果に基づく調整。
RL-KSP（近似率~100%）との比較分析から、学習信号の弱さとCriticの不安定さが特定された。

## Test plan
- [ ] `python scripts/gnn_ils/train_gnn_ils.py --config configs/gnn_ils/gnn_ils_base.json` で学習を実行
- [ ] 初期Lossが5548→正常範囲に収まることを確認
- [ ] Val Approx%が65%から改善するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)