### PR TITLE
fix: GNN-ILS NSFNet config ハイパーパラメータ調整

### DIFF
--- a/configs/gnn_ils/gnn_ils_nsfnet.json
+++ b/configs/gnn_ils/gnn_ils_nsfnet.json
@@ -30,7 +30,7 @@
     "commodity_selector_mlp_layers": 2,
     "path_selector_mlp_layers": 2,
     "value_head_mlp_layers": 3,
-    "use_graph_embedding_value": false,
+    "use_graph_embedding_value": true,
 
     "_comment_path_pool": "=== Path Pool Configuration ===",
     "K": 10,
@@ -47,7 +47,8 @@
     "entropy_weight_l2": 0.003,
     "_entropy_note": "L1 (C択) は探索空間が小さいため大きめ、L2 (パス択) は小さめ",
     "value_loss_weight": 0.5,
-    "gamma": 0.99,
+    "gamma": 0.95,
+    "reward_scale": 100.0,
     "normalize_advantages": true,
     "grad_clip_norm": 1.0,
     "reward_mode": "shared",


### PR DESCRIPTION
## Summary

- `use_graph_embedding_value`: `false` → `true`（Value Head にグラフ埋め込みを使用）
- `gamma`: `0.99` → `0.95`（割引率を下げ短期報酬を重視）
- `reward_scale: 100.0` を追加（報酬スケーリング）

## Test plan

- [ ] GNN-ILS NSFNet 設定で学習が正常に開始されることを確認
- [ ] Value loss が安定して収束することを確認
- [ ] Load Factor が改善されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)