### PR TITLE
fix: GNN-ILS Level1 CommoditySelectorの入力をパス混雑度ベースに変更

### DIFF
--- a/src/gnn_ils/models/commodity_selector.py
+++ b/src/gnn_ils/models/commodity_selector.py
@@ -11,13 +11,12 @@ class CommoditySelector(nn.Module):
     """
     Level1 Policy: コモディティ選択。
 
-    各コモディティのノード集約特徴量 + グラフ埋め込みから
+    各コモディティの現パス上エッジ特徴量の mean-pooling + demand から
     交換対象コモディティを選択する。
 
     入力処理:
-        node_features [B, V, C, H] → mean over V → [B, C, H]
-        graph_embedding [B, H] → expand → [B, C, H]
-        concat → [B, C, 2H] → MLP per commodity → scores [B, C]
+        path_commodity_features [B, C, H+1] (呼び出し側で構築済み)
+        → MLP per commodity → scores [B, C]
         masked softmax → probabilities [B, C]
     """
 
@@ -28,7 +27,7 @@ class CommoditySelector(nn.Module):
 
         hidden_dims = [128] * (mlp_layers - 1)
         self.commodity_mlp = MLP(
-            hidden_dim * 2,
+            hidden_dim + 1,
             1,
             num_layers=mlp_layers,
             hidden_dims=hidden_dims,
@@ -36,9 +35,8 @@ class CommoditySelector(nn.Module):
 
     def forward(
         self,
-        node_features: Tensor,   # [B, V, C, H]
-        graph_embedding: Tensor, # [B, H]
-        commodity_mask: Tensor,  # [B, C] - bool (True = 交換可能)
+        path_commodity_features: Tensor,  # [B, C, H+1]
+        commodity_mask: Tensor,           # [B, C] - bool (True = 交換可能)
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """
         Returns:
@@ -48,17 +46,8 @@ class CommoditySelector(nn.Module):
         """
         B, C = commodity_mask.shape
 
-        # コモディティ毎のノード集約特徴量: [B, V, C, H] → [B, C, H]
-        commodity_feats = node_features.mean(dim=1)  # [B, C, H]
-
-        # グラフ埋め込みをコモディティ次元に展開: [B, H] → [B, C, H]
-        graph_exp = graph_embedding.unsqueeze(1).expand(-1, C, -1)
-
-        # 結合: [B, C, 2H]
-        combined = torch.cat([commodity_feats, graph_exp], dim=-1)
-
-        # MLP でスコア算出: [B*C, 2H] → [B*C, 1] → [B, C]
-        scores = self.commodity_mlp(combined.view(B * C, -1)).view(B, C)
+        # MLP でスコア算出: [B*C, H+1] → [B*C, 1] → [B, C]
+        scores = self.commodity_mlp(path_commodity_features.view(B * C, -1)).view(B, C)
 
         # マスク適用 (交換不可コモディティを -inf に)
         scores = scores.masked_fill(~commodity_mask, float('-inf'))

--- a/src/gnn_ils/models/gnn_ils_model.py
+++ b/src/gnn_ils/models/gnn_ils_model.py
@@ -35,6 +35,8 @@ class GNNILSModel(nn.Module):
         super().__init__()
         self.dtypeFloat = dtypeFloat
         self.dtypeLong = dtypeLong
+        self.demand_max = config.get('demand_higher', 500)
+        self.path_aggregation = config.get('path_aggregation', 'mean')
 
         self.encoder = GNNILSEncoder(config)
 
@@ -78,9 +80,10 @@ class GNNILSModel(nn.Module):
 
     def select_commodity(
         self,
-        node_features: Tensor,   # [B, V, C, H]
-        graph_embedding: Tensor, # [B, H]
-        commodity_mask: Tensor,  # [B, C]
+        edge_features: Tensor,                        # [B, V, V, C, H]
+        current_assignment: List[List[List[int]]],     # [B][C][path_length]
+        demands: Tensor,                               # [B, C]
+        commodity_mask: Tensor,                        # [B, C]
         deterministic: bool = False,
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """
@@ -91,8 +94,11 @@ class GNNILSModel(nn.Module):
             log_prob:           [B] - 選択されたコモディティの対数確率
             entropy:            [B]
         """
+        path_commodity_features = self._build_commodity_path_features(
+            edge_features, current_assignment, demands
+        )
         action_probs, log_probs_all, entropy = self.commodity_selector(
-            node_features, graph_embedding, commodity_mask
+            path_commodity_features, commodity_mask
         )
 
         if deterministic:
@@ -146,3 +152,37 @@ class GNNILSModel(nn.Module):
             state_value: [B]
         """
         return self.value_head(node_features, graph_embedding)
+
+    def _build_commodity_path_features(
+        self,
+        edge_features: Tensor,                     # [B, V, V, C, H]
+        current_assignment: List[List[List[int]]],  # [B][C][path_length]
+        demands: Tensor,                            # [B, C]
+    ) -> Tensor:
+        """
+        各コモディティの現パス上 edge_features を集約し、
+        正規化 demand と結合して [B, C, H+1] を返す。
+        """
+        B, V, _, C, H = edge_features.shape
+        device = edge_features.device
+
+        path_feats = torch.zeros(B, C, H, device=device)
+        for b in range(B):
+            for c in range(C):
+                path = current_assignment[b][c]
+                if len(path) < 2:
+                    continue
+                edge_list = []
+                for i in range(len(path) - 1):
+                    u, v = path[i], path[i + 1]
+                    edge_list.append(edge_features[b, u, v, c, :])
+                stacked = torch.stack(edge_list)  # [num_edges, H]
+                if self.path_aggregation == 'max':
+                    path_feats[b, c] = stacked.max(dim=0).values
+                else:
+                    path_feats[b, c] = stacked.mean(dim=0)
+
+        # demand 正規化: [B, C] → [B, C, 1]
+        demand_norm = (demands / self.demand_max).unsqueeze(-1)
+
+        return torch.cat([path_feats, demand_norm], dim=-1)  # [B, C, H+1]

--- a/src/gnn_ils/training/ils_a2c_strategy.py
+++ b/src/gnn_ils/training/ils_a2c_strategy.py
@@ -154,8 +154,11 @@ class ILSA2CStrategy:
             state_value = self.model.get_value(node_features, graph_embedding)
 
             # Level1: コモディティ選択
+            demands = state['x_commodities'][:, :, 2].to(self.device)  # [1, C]
+            current_assignment_batch = [state['current_assignment']]     # [1][C][path_length]
             selected_commodity, log_prob_l1, entropy_l1 = self.model.select_commodity(
-                node_features, graph_embedding, commodity_mask, deterministic=deterministic
+                edge_features, current_assignment_batch, demands,
+                commodity_mask, deterministic=deterministic
             )
             c_idx = selected_commodity[0].item()
 


### PR DESCRIPTION
## Summary

- GNN-ILS Level1 (CommoditySelector) の入力を `node_features平均 + graph_embedding [B, C, 2H]` から、**各コモディティの現パス上 edge_features の集約 + 正規化 demand `[B, C, H+1]`** に変更
- 同じ src/dst を持つコモディティでも、パス毎の混雑度の違いを区別できるようになる
- 集約方法を config の `path_aggregation` で `mean` / `max` から選択可能（デフォルト: `mean`）

## 変更内容

| ファイル | 変更 |
|---|---|
| `commodity_selector.py` | MLP入力次元 `hidden_dim*2` → `hidden_dim+1`、forward引数を `path_commodity_features` に簡素化 |
| `gnn_ils_model.py` | `_build_commodity_path_features` メソッド追加、`select_commodity` シグネチャ変更 |
| `ils_a2c_strategy.py` | `select_commodity` 呼び出し箇所で `demands` / `current_assignment` を渡すように修正 |

## 注意事項

- MLP入力次元が変わるため **保存済みモデルとの互換性なし**（再学習が必要）
- `demand_higher` は既存 config に存在するため設定ファイル変更不要

## Test plan

- [ ] `python scripts/gnn_ils/train_gnn_ils.py --config configs/gnn_ils/gnn_ils_base.json` で1エポック学習が正常完了
- [ ] `actor_l1_loss` が nan/inf にならないことを確認
- [ ] `path_aggregation: "max"` での動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)