### PR TITLE
fix: GNN-ILS Level2 PathSelectorの入力設計見直し

### DIFF
--- a/src/gnn_ils/models/gnn_ils_model.py
+++ b/src/gnn_ils/models/gnn_ils_model.py
@@ -54,6 +54,7 @@ class GNNILSModel(nn.Module):
             hidden_dim=hidden_dim,
             max_paths=max_paths,
             mlp_layers=config.get('path_selector_mlp_layers', 2),
+            path_aggregation=self.path_aggregation,
         )
         self.value_head = ILSValueHead(
             hidden_dim=hidden_dim,
@@ -113,9 +114,10 @@ class GNNILSModel(nn.Module):
     def select_path(
         self,
         edge_features: Tensor,                   # [B, V, V, C, H]
-        graph_embedding: Tensor,                 # [B, H]
         selected_commodity: Tensor,              # [B]
         candidate_paths: List[List[List[int]]],  # [B][P_c][path_length]
+        current_paths: List[List[int]],          # [B][path_length] (選択コモディティの現パス)
+        demands: Tensor,                         # [B] (生の demand、正規化はモデル内で行う)
         path_mask: Tensor,                       # [B, max_paths]
         deterministic: bool = False,
     ) -> Tuple[Tensor, Tensor, Tensor]:
@@ -127,8 +129,9 @@ class GNNILSModel(nn.Module):
             log_prob:          [B]
             entropy:           [B]
         """
+        demands_norm = demands / self.demand_max
         action_probs, log_probs_all, entropy = self.path_selector(
-            edge_features, graph_embedding, selected_commodity, candidate_paths, path_mask
+            edge_features, selected_commodity, candidate_paths, current_paths, demands_norm, path_mask
         )
 
         if deterministic:

--- a/src/gnn_ils/models/path_selector.py
+++ b/src/gnn_ils/models/path_selector.py
@@ -12,22 +12,25 @@ class PathSelector(nn.Module):
     Level2 Policy: パス選択。
 
     選択されたコモディティに対し、候補パスプールから最適なパスを選択する。
-    パス特徴量はパス上のエッジ特徴量の mean-pooling で表現する。
+    各候補パスについて concat(cand_feat [H], current_feat [H], demand_norm [1]) -> [2H+1]
+    を MLP に通してスコアを計算する。
 
     入力処理:
-        各候補パスについて: edge_features[b, u, v, c, :] を mean-pool → [H]
-        path_feat [H] + graph_embedding [H] → concat [2H] → MLP → スコア
+        各候補パスについて: edge_features[b, u, v, c, :] を aggregation → [H]
+        concat(cand_feat [H], current_feat [H], demand_norm [1]) → [2H+1] → MLP → スコア
         masked softmax → probabilities [B, max_paths]
     """
 
-    def __init__(self, hidden_dim: int, max_paths: int, mlp_layers: int = 2):
+    def __init__(self, hidden_dim: int, max_paths: int, mlp_layers: int = 2,
+                 path_aggregation: str = 'mean'):
         super().__init__()
         self.hidden_dim = hidden_dim
         self.max_paths = max_paths
+        self.path_aggregation = path_aggregation
 
         hidden_dims = [128] * (mlp_layers - 1)
         self.path_score_mlp = MLP(
-            hidden_dim * 2,
+            hidden_dim * 2 + 1,
             1,
             num_layers=mlp_layers,
             hidden_dims=hidden_dims,
@@ -36,9 +39,10 @@ class PathSelector(nn.Module):
     def forward(
         self,
         edge_features: Tensor,                       # [B, V, V, C, H]
-        graph_embedding: Tensor,                     # [B, H]
         selected_commodity: Tensor,                  # [B] - int
         candidate_paths: List[List[List[int]]],      # [B][P_c][path_length]
+        current_paths: List[List[int]],              # [B][path_length] (選択コモディティの現パス)
+        demands: Tensor,                             # [B] (正規化済み demand)
         path_mask: Tensor,                           # [B, max_paths] - bool
     ) -> Tuple[Tensor, Tensor, Tensor]:
         """
@@ -48,19 +52,20 @@ class PathSelector(nn.Module):
             entropy:      [B]
         """
         B = edge_features.shape[0]
-        H = self.hidden_dim
         scores = torch.full((B, self.max_paths), float('-inf'), device=edge_features.device)
 
         for b in range(B):
             c_idx = selected_commodity[b].item()
             paths = candidate_paths[b]  # List[List[int]]
-            g_emb = graph_embedding[b]  # [H]
+            # 現パスの特徴量を1回だけ計算
+            current_feat = self._encode_path(edge_features, current_paths[b], c_idx, b)  # [H]
+            demand_val = demands[b].unsqueeze(0)  # [1]
 
             for p_idx, path in enumerate(paths):
                 if p_idx >= self.max_paths:
                     break
-                path_feat = self._encode_path(edge_features, path, c_idx, b)  # [H]
-                inp = torch.cat([path_feat, g_emb], dim=0).unsqueeze(0)       # [1, 2H]
+                cand_feat = self._encode_path(edge_features, path, c_idx, b)  # [H]
+                inp = torch.cat([cand_feat, current_feat, demand_val], dim=0).unsqueeze(0)  # [1, 2H+1]
                 scores[b, p_idx] = self.path_score_mlp(inp).squeeze()
 
         # パスマスク適用
@@ -96,4 +101,7 @@ class PathSelector(nn.Module):
             u, v = path[i], path[i + 1]
             edge_feats.append(edge_features[batch_idx, u, v, commodity_idx, :])
 
-        return torch.stack(edge_feats).mean(dim=0)  # [H]
+        stacked = torch.stack(edge_feats)  # [num_edges, H]
+        if self.path_aggregation == 'max':
+            return stacked.max(dim=0).values
+        return stacked.mean(dim=0)  # [H]

--- a/src/gnn_ils/training/ils_a2c_strategy.py
+++ b/src/gnn_ils/training/ils_a2c_strategy.py
@@ -166,9 +166,12 @@ class ILSA2CStrategy:
             path_mask = self.env.get_path_mask(c_idx).to(self.device)
             candidate_paths = [state['path_pool'][c_idx]]  # [1][P_c][path_length]
 
+            current_paths_batch = [state['current_assignment'][c_idx]]  # [1][path_length]
+            demand_c = demands[:, c_idx]  # [1] (生の demand、正規化はモデル内で行う)
             selected_path_idx, log_prob_l2, entropy_l2 = self.model.select_path(
-                edge_features, graph_embedding, selected_commodity,
-                candidate_paths, path_mask, deterministic=deterministic
+                edge_features, selected_commodity,
+                candidate_paths, current_paths_batch, demand_c,
+                path_mask, deterministic=deterministic
             )
 
             # 環境を1ステップ進める


### PR DESCRIPTION
## Summary
- PathSelector (Level2) の入力を `graph_embedding` ベースから `current_path + demand_norm` ベースに変更
- MLP入力: `concat(cand_feat [H], current_feat [H], demand_norm [1])` → `[2H+1]`
- 現パス解放効果を考慮可能にし、候補パスの混雑度だけでなく切り替え前後の比較が可能に
- `_encode_path` に `path_aggregation` (mean/max) 対応を追加（L1と統一）

## Changes
- `src/gnn_ils/models/path_selector.py` — MLP入力次元変更 + forwardシグネチャ変更
- `src/gnn_ils/models/gnn_ils_model.py` — `select_path`シグネチャ変更 + demand正規化
- `src/gnn_ils/training/ils_a2c_strategy.py` — 呼び出し引数の修正

## Test plan
- [x] 単体テスト (PathSelector + GNNILSModel) 通過確認
- [ ] `python scripts/gnn_ils/train_gnn_ils.py --config configs/gnn_ils/gnn_ils_base.json` で1エポック学習が正常完了すること
- [ ] actor_l2_loss が nan/inf にならないこと

## Note
保存済みモデルとは非互換 (MLP入力次元 2H → 2H+1)。再学習が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)