### PR TITLE
feat: GNN-ILS PPO導入 + Critic安定化

### DIFF
--- a/configs/gnn_ils/gnn_ils_base.json
+++ b/configs/gnn_ils/gnn_ils_base.json
@@ -42,7 +42,16 @@
     "no_improve_patience": 10,
     "perturbation_prob": 0.1,
 
-    "_comment_rl": "=== RL Algorithm (A2C) ===",
+    "_comment_rl": "=== RL Algorithm (A2C / PPO) ===",
+    "_comment_critic_stability": "=== Critic Stability ===",
+    "value_head_bias_init": -2.0,
+    "warmup_epochs": 3,
+
+    "_comment_ppo": "=== PPO Configuration ===",
+    "use_ppo": false,
+    "ppo_clip_eps": 0.2,
+    "ppo_update_epochs": 4,
+
     "entropy_weight_l1": 0.005,
     "entropy_weight_l2": 0.003,
     "_entropy_note": "L1 (C択) は探索空間が小さいため大きめ、L2 (パス択) は小さめ",

--- a/configs/gnn_ils/gnn_ils_base.json
+++ b/configs/gnn_ils/gnn_ils_base.json
@@ -50,7 +50,8 @@
     "_comment_ppo": "=== PPO Configuration ===",
     "use_ppo": false,
     "ppo_clip_eps": 0.2,
-    "ppo_update_epochs": 4,
+    "ppo_update_epochs": 1,
+    "_ppo_update_epochs_note": "start=1, increase if clip_frac stays < 0.1",
 
     "entropy_weight_l1": 0.005,
     "entropy_weight_l2": 0.003,

--- a/configs/gnn_ils/gnn_ils_nsfnet.json
+++ b/configs/gnn_ils/gnn_ils_nsfnet.json
@@ -42,7 +42,16 @@
     "no_improve_patience": 10,
     "perturbation_prob": 0.1,
 
-    "_comment_rl": "=== RL Algorithm (A2C) ===",
+    "_comment_rl": "=== RL Algorithm (A2C / PPO) ===",
+    "_comment_critic_stability": "=== Critic Stability ===",
+    "value_head_bias_init": -2.0,
+    "warmup_epochs": 3,
+
+    "_comment_ppo": "=== PPO Configuration ===",
+    "use_ppo": false,
+    "ppo_clip_eps": 0.2,
+    "ppo_update_epochs": 4,
+
     "entropy_weight_l1": 0.005,
     "entropy_weight_l2": 0.003,
     "_entropy_note": "L1 (C択) は探索空間が小さいため大きめ、L2 (パス択) は小さめ",

--- a/configs/gnn_ils/gnn_ils_nsfnet.json
+++ b/configs/gnn_ils/gnn_ils_nsfnet.json
@@ -50,7 +50,8 @@
     "_comment_ppo": "=== PPO Configuration ===",
     "use_ppo": false,
     "ppo_clip_eps": 0.2,
-    "ppo_update_epochs": 4,
+    "ppo_update_epochs": 1,
+    "_ppo_update_epochs_note": "start=1, increase if clip_frac stays < 0.1",
 
     "entropy_weight_l1": 0.005,
     "entropy_weight_l2": 0.003,

--- a/src/gnn_ils/models/gnn_ils_model.py
+++ b/src/gnn_ils/models/gnn_ils_model.py
@@ -62,6 +62,7 @@ class GNNILSModel(nn.Module):
             num_commodities=num_commodities,
             mlp_layers=config.get('value_head_mlp_layers', 3),
             use_graph_embedding=config.get('use_graph_embedding_value', False),
+            bias_init_value=config.get('value_head_bias_init', 0.0),
         )
 
     def encode(

--- a/src/gnn_ils/models/value_head.py
+++ b/src/gnn_ils/models/value_head.py
@@ -24,6 +24,7 @@ class ILSValueHead(nn.Module):
         num_commodities: int,
         mlp_layers: int = 3,
         use_graph_embedding: bool = False,
+        bias_init_value: float = 0.0,
     ):
         super().__init__()
         self.use_graph_embedding = use_graph_embedding
@@ -46,6 +47,9 @@ class ILSValueHead(nn.Module):
                 hidden_dims = []
 
         self.value_mlp = MLP(input_dim, 1, num_layers=mlp_layers, hidden_dims=hidden_dims)
+
+        if bias_init_value != 0.0:
+            nn.init.constant_(self.value_mlp.output_layer.bias, bias_init_value)
 
     def forward(
         self,

--- a/src/gnn_ils/training/ils_a2c_strategy.py
+++ b/src/gnn_ils/training/ils_a2c_strategy.py
@@ -1,3 +1,4 @@
+import copy
 import torch
 import torch.nn.functional as F
 import numpy as np
@@ -9,16 +10,19 @@ from src.gnn_ils.environment.ils_environment import ILSEnvironment
 
 class ILSA2CStrategy:
     """
-    2段階 A2C Training Strategy for GNN-ILS。
+    2段階 A2C / PPO Training Strategy for GNN-ILS。
 
     ILS改善ループ内で Level1 (コモディティ選択) + Level2 (パス選択) の
-    ログ確率・Value・エントロピーを蓄積し、エピソード終了時に A2C 損失を計算する。
+    ログ確率・Value・エントロピーを蓄積し、エピソード終了時に損失を計算する。
 
-    損失:
+    損失 (A2C):
         L = L_actor_l1 + L_actor_l2
             + value_loss_weight * L_critic
             - entropy_weight_l1 * H_l1
             - entropy_weight_l2 * H_l2
+
+    PPO モード (use_ppo=True):
+        クリップされた surrogate objective で複数回更新。
     """
 
     def __init__(self, model: GNNILSModel, config: dict):
@@ -30,6 +34,7 @@ class ILSA2CStrategy:
                 - value_loss_weight, gamma
                 - normalize_advantages, grad_clip_norm
                 - reward_mode, max_iterations, no_improve_patience
+                - warmup_epochs, use_ppo, ppo_clip_eps, ppo_update_epochs
         """
         self.model = model
         self.config = config
@@ -41,6 +46,15 @@ class ILSA2CStrategy:
         self.gamma = config.get('gamma', 0.99)
         self.normalize_advantages = config.get('normalize_advantages', True)
         self.grad_clip_norm = config.get('grad_clip_norm', 1.0)
+
+        # Critic warm-up
+        self.warmup_epochs = config.get('warmup_epochs', 0)
+        self.current_epoch = 0
+
+        # PPO
+        self.use_ppo = config.get('use_ppo', False)
+        self.ppo_clip_eps = config.get('ppo_clip_eps', 0.2)
+        self.ppo_update_epochs = config.get('ppo_update_epochs', 4)
 
         self.optimizer = torch.optim.Adam(
             model.parameters(),
@@ -66,15 +80,16 @@ class ILSA2CStrategy:
 
         self.env = ILSEnvironment(config)
 
+    def set_epoch(self, epoch: int):
+        """現在のエポック番号を設定する (warm-up 判定用)。"""
+        self.current_epoch = epoch
+
     def train_step(self, batch_data: Dict[str, Any]) -> Dict[str, float]:
         """
         1サンプルの ILS エピソードを実行し、損失を計算・更新する。
 
-        Args:
-            batch_data:
-                - x_nodes [1, V, C], x_commodities [1, C, 3],
-                  x_edges_capacity [1, V, V], load_factor [1]
-                - graph: nx.Graph, commodity_list: List[List[int]]
+        PPO モード: 同一 trajectory に対して複数回更新。
+        A2C モード: 1回更新 (従来と同一)。
 
         Returns:
             metrics 辞書
@@ -86,6 +101,15 @@ class ILSA2CStrategy:
         if len(trajectory['rewards']) == 0:
             return self._empty_metrics()
 
+        if self.use_ppo:
+            metrics = self._ppo_update(trajectory)
+        else:
+            metrics = self._a2c_update(trajectory)
+
+        return metrics
+
+    def _a2c_update(self, trajectory: Dict) -> Dict[str, float]:
+        """従来の A2C 1回更新パス。"""
         loss, loss_components = self._compute_a2c_loss(trajectory)
 
         self.optimizer.zero_grad()
@@ -94,6 +118,50 @@ class ILSA2CStrategy:
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.grad_clip_norm)
         self.optimizer.step()
 
+        return self._build_train_metrics(trajectory, loss_components)
+
+    def _ppo_update(self, trajectory: Dict) -> Dict[str, float]:
+        """PPO 複数回更新パス。"""
+        # old log_probs を detach
+        log_probs_l1_old = torch.stack(trajectory['log_probs_l1']).detach()  # [T]
+        log_probs_l2_old = torch.stack(trajectory['log_probs_l2']).detach()  # [T]
+
+        # returns を事前計算
+        rewards = trajectory['rewards']
+        T = len(rewards)
+        R = 0.0
+        returns = []
+        for r in reversed(rewards):
+            R = r + self.gamma * R
+            returns.insert(0, R)
+        returns_t = torch.tensor(returns, dtype=torch.float32, device=self.device)
+
+        last_loss_components = None
+
+        for ppo_epoch in range(self.ppo_update_epochs):
+            # 現在のポリシーで re-forward
+            (log_probs_l1_new, log_probs_l2_new,
+             entropies_l1, entropies_l2, state_values) = self._recompute_log_probs_and_values(trajectory)
+
+            loss, loss_components = self._compute_ppo_loss(
+                log_probs_l1_old, log_probs_l2_old,
+                log_probs_l1_new, log_probs_l2_new,
+                entropies_l1, entropies_l2,
+                state_values, returns_t,
+            )
+
+            self.optimizer.zero_grad()
+            loss.backward()
+            if self.grad_clip_norm > 0:
+                torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.grad_clip_norm)
+            self.optimizer.step()
+
+            last_loss_components = loss_components
+
+        return self._build_train_metrics(trajectory, last_loss_components)
+
+    def _build_train_metrics(self, trajectory: Dict, loss_components: Dict[str, float]) -> Dict[str, float]:
+        """共通メトリクス構築。"""
         improvement = 0.0
         init_lf = trajectory['initial_load_factor']
         final_lf = trajectory['final_load_factor']
@@ -117,8 +185,10 @@ class ILSA2CStrategy:
         """
         ILS エピソードを実行し、trajectory を収集する。
 
+        PPO モードでは各ステップの中間状態も保存する。
+
         Returns:
-            trajectory 辞書 (log_probs, values, rewards など)
+            trajectory 辞書 (log_probs, values, rewards, states など)
         """
         state = self.env.reset(
             G=batch_data['graph'],
@@ -128,7 +198,7 @@ class ILSA2CStrategy:
             x_edges_capacity=batch_data['x_edges_capacity'],
         )
 
-        trajectory: Dict[str, List] = {
+        trajectory: Dict[str, Any] = {
             'log_probs_l1': [],
             'log_probs_l2': [],
             'entropies_l1': [],
@@ -138,6 +208,15 @@ class ILSA2CStrategy:
             'initial_load_factor': state['load_factor'],
             'final_load_factor': state['load_factor'],
         }
+
+        # PPO: 不変入力と各ステップの状態を保存
+        if self.use_ppo and not deterministic:
+            trajectory['static_inputs'] = {
+                'x_nodes': batch_data['x_nodes'].detach().clone(),
+                'x_commodities': batch_data['x_commodities'].detach().clone(),
+                'x_edges_capacity': batch_data['x_edges_capacity'].detach().clone(),
+            }
+            trajectory['states'] = []
 
         done = False
         while not done:
@@ -181,6 +260,23 @@ class ILSA2CStrategy:
                 path_mask, deterministic=deterministic
             )
 
+            # PPO: 中間状態を保存
+            if self.use_ppo and not deterministic:
+                step_state = {
+                    'x_edges_usage': x_edges_usage.detach().clone(),
+                    'commodity_mask': commodity_mask.detach().clone(),
+                    'current_assignment': copy.deepcopy(state['current_assignment']),
+                    'demands': demands.detach().clone(),
+                    'selected_commodity_idx': c_idx,
+                    'path_mask': path_mask.detach().clone(),
+                    'candidate_paths': copy.deepcopy(candidate_paths),
+                    'current_paths': copy.deepcopy(current_paths_batch),
+                    'demand_c': demand_c.detach().clone(),
+                    'action_l1': selected_commodity.detach().clone(),  # [1]
+                    'action_l2': selected_path_idx.detach().clone(),   # [1]
+                }
+                trajectory['states'].append(step_state)
+
             # 環境を1ステップ進める
             new_state, reward, done, info = self.env.step(
                 c_idx, selected_path_idx[0].item()
@@ -204,6 +300,161 @@ class ILSA2CStrategy:
 
         return trajectory
 
+    def _recompute_log_probs_and_values(
+        self, trajectory: Dict
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """
+        保存された trajectory の各ステップを現在のポリシーで re-forward し、
+        同じアクションに対する log_prob と value を再計算する。
+
+        Returns:
+            (log_probs_l1_new, log_probs_l2_new, entropies_l1, entropies_l2, state_values)
+            全て [T]
+        """
+        static = trajectory['static_inputs']
+        x_nodes = static['x_nodes'].to(self.device)
+        x_commodities = static['x_commodities'].to(self.device)
+        x_edges_capacity = static['x_edges_capacity'].to(self.device)
+
+        log_probs_l1_list = []
+        log_probs_l2_list = []
+        entropies_l1_list = []
+        entropies_l2_list = []
+        state_values_list = []
+
+        for step_state in trajectory['states']:
+            x_edges_usage = step_state['x_edges_usage'].to(self.device)
+            commodity_mask = step_state['commodity_mask'].to(self.device)
+            demands = step_state['demands'].to(self.device)
+
+            # GNN エンコード
+            node_features, edge_features, graph_embedding = self.model.encode(
+                x_nodes, x_commodities, x_edges_capacity, x_edges_usage
+            )
+
+            # Critic
+            state_value = self.model.get_value(node_features, graph_embedding)
+
+            # Level1: 保存されたアクションの log_prob を取得
+            current_assignment_batch = [step_state['current_assignment']]
+            path_commodity_features = self.model._build_commodity_path_features(
+                edge_features, current_assignment_batch, demands
+            )
+            action_probs_l1, log_probs_all_l1, entropy_l1 = self.model.commodity_selector(
+                path_commodity_features, commodity_mask
+            )
+            action_l1 = step_state['action_l1'].to(self.device)  # [1]
+            log_prob_l1 = log_probs_all_l1.gather(1, action_l1.unsqueeze(1)).squeeze(1)  # [1]
+
+            # Level2: 保存されたアクションの log_prob を取得
+            path_mask = step_state['path_mask'].to(self.device)
+            candidate_paths = step_state['candidate_paths']
+            current_paths = step_state['current_paths']
+            demand_c = step_state['demand_c'].to(self.device)
+            demands_norm = demand_c / self.model.demand_max
+            action_probs_l2, log_probs_all_l2, entropy_l2 = self.model.path_selector(
+                edge_features, action_l1, candidate_paths, current_paths, demands_norm, path_mask
+            )
+            action_l2 = step_state['action_l2'].to(self.device)  # [1]
+            log_prob_l2 = log_probs_all_l2.gather(1, action_l2.unsqueeze(1)).squeeze(1)  # [1]
+
+            log_probs_l1_list.append(log_prob_l1[0])
+            log_probs_l2_list.append(log_prob_l2[0])
+            entropies_l1_list.append(entropy_l1[0])
+            entropies_l2_list.append(entropy_l2[0])
+            state_values_list.append(state_value[0])
+
+        return (
+            torch.stack(log_probs_l1_list),
+            torch.stack(log_probs_l2_list),
+            torch.stack(entropies_l1_list),
+            torch.stack(entropies_l2_list),
+            torch.stack(state_values_list),
+        )
+
+    def _compute_ppo_loss(
+        self,
+        log_probs_l1_old: torch.Tensor,  # [T] detached
+        log_probs_l2_old: torch.Tensor,  # [T] detached
+        log_probs_l1_new: torch.Tensor,  # [T]
+        log_probs_l2_new: torch.Tensor,  # [T]
+        entropies_l1: torch.Tensor,      # [T]
+        entropies_l2: torch.Tensor,      # [T]
+        state_values: torch.Tensor,      # [T]
+        returns_t: torch.Tensor,         # [T]
+    ) -> Tuple[torch.Tensor, Dict[str, float]]:
+        """
+        PPO クリップ損失を計算する。
+
+        Returns:
+            (total_loss, loss_components 辞書)
+        """
+        T = returns_t.shape[0]
+        eps = self.ppo_clip_eps
+        is_warmup = self.current_epoch < self.warmup_epochs
+
+        # Advantage
+        advantages = returns_t - state_values.detach()
+        adv_mean_raw = advantages.mean().item()
+        adv_std_raw = advantages.std().item() if T > 1 else 0.0
+        if self.normalize_advantages and T > 1:
+            advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
+
+        # PPO clipped surrogate — Level1
+        ratio_l1 = torch.exp(log_probs_l1_new - log_probs_l1_old)
+        clipped_l1 = torch.clamp(ratio_l1, 1.0 - eps, 1.0 + eps)
+        actor_l1_loss = -torch.min(ratio_l1 * advantages, clipped_l1 * advantages).mean()
+
+        # PPO clipped surrogate — Level2
+        ratio_l2 = torch.exp(log_probs_l2_new - log_probs_l2_old)
+        clipped_l2 = torch.clamp(ratio_l2, 1.0 - eps, 1.0 + eps)
+        actor_l2_loss = -torch.min(ratio_l2 * advantages, clipped_l2 * advantages).mean()
+
+        # Critic loss
+        critic_loss = F.mse_loss(state_values, returns_t)
+
+        # Entropy
+        entropy_l1_mean = entropies_l1.mean()
+        entropy_l2_mean = entropies_l2.mean()
+
+        # Warm-up: Actor 損失を無効化
+        if is_warmup:
+            actor_l1_loss_effective = torch.tensor(0.0, device=self.device)
+            actor_l2_loss_effective = torch.tensor(0.0, device=self.device)
+        else:
+            actor_l1_loss_effective = actor_l1_loss
+            actor_l2_loss_effective = actor_l2_loss
+
+        total_loss = (
+            actor_l1_loss_effective
+            + actor_l2_loss_effective
+            + self.value_loss_weight * critic_loss
+            - self.entropy_weight_l1 * entropy_l1_mean
+            - self.entropy_weight_l2 * entropy_l2_mean
+        )
+
+        # 診断メトリクス
+        with torch.no_grad():
+            clip_frac_l1 = ((ratio_l1 - 1.0).abs() > eps).float().mean().item()
+            clip_frac_l2 = ((ratio_l2 - 1.0).abs() > eps).float().mean().item()
+
+        loss_components = {
+            'total_loss': total_loss.item(),
+            'actor_l1_loss': actor_l1_loss.item(),
+            'actor_l2_loss': actor_l2_loss.item(),
+            'critic_loss': critic_loss.item(),
+            'entropy_l1': entropy_l1_mean.item(),
+            'entropy_l2': entropy_l2_mean.item(),
+            'advantage_mean': adv_mean_raw,
+            'advantage_std': adv_std_raw,
+            'is_warmup': is_warmup,
+            'ratio_l1_mean': ratio_l1.mean().item(),
+            'ratio_l2_mean': ratio_l2.mean().item(),
+            'clip_frac_l1': clip_frac_l1,
+            'clip_frac_l2': clip_frac_l2,
+        }
+        return total_loss, loss_components
+
     def _compute_a2c_loss(
         self, trajectory: Dict
     ) -> Tuple[torch.Tensor, Dict[str, float]]:
@@ -219,6 +470,7 @@ class ILSA2CStrategy:
         """
         rewards = trajectory['rewards']
         T = len(rewards)
+        is_warmup = self.current_epoch < self.warmup_epochs
 
         # Discounted returns
         R = 0.0
@@ -252,9 +504,17 @@ class ILSA2CStrategy:
         entropy_l1_mean = entropies_l1.mean()
         entropy_l2_mean = entropies_l2.mean()
 
+        # Warm-up: Actor 損失を無効化
+        if is_warmup:
+            actor_l1_loss_effective = torch.tensor(0.0, device=self.device)
+            actor_l2_loss_effective = torch.tensor(0.0, device=self.device)
+        else:
+            actor_l1_loss_effective = actor_l1_loss
+            actor_l2_loss_effective = actor_l2_loss
+
         total_loss = (
-            actor_l1_loss
-            + actor_l2_loss
+            actor_l1_loss_effective
+            + actor_l2_loss_effective
             + self.value_loss_weight * critic_loss
             - self.entropy_weight_l1 * entropy_l1_mean
             - self.entropy_weight_l2 * entropy_l2_mean
@@ -267,8 +527,8 @@ class ILSA2CStrategy:
             grads = torch.autograd.grad(loss, params, retain_graph=True, allow_unused=True)
             return float(sum(g.norm().item() for g in grads if g is not None))
 
-        grad_norm_l1 = _grad_norm(actor_l1_loss, l1_params)
-        grad_norm_l2 = _grad_norm(actor_l2_loss, l2_params)
+        grad_norm_l1 = _grad_norm(actor_l1_loss, l1_params) if not is_warmup else 0.0
+        grad_norm_l2 = _grad_norm(actor_l2_loss, l2_params) if not is_warmup else 0.0
 
         loss_components = {
             'total_loss': total_loss.item(),
@@ -281,6 +541,7 @@ class ILSA2CStrategy:
             'grad_norm_l2': grad_norm_l2,
             'advantage_mean': adv_mean_raw,
             'advantage_std':  adv_std_raw,
+            'is_warmup': is_warmup,
         }
         return total_loss, loss_components
 

--- a/src/gnn_ils/training/ils_a2c_strategy.py
+++ b/src/gnn_ils/training/ils_a2c_strategy.py
@@ -54,7 +54,7 @@ class ILSA2CStrategy:
         # PPO
         self.use_ppo = config.get('use_ppo', False)
         self.ppo_clip_eps = config.get('ppo_clip_eps', 0.2)
-        self.ppo_update_epochs = config.get('ppo_update_epochs', 4)
+        self.ppo_update_epochs = config.get('ppo_update_epochs', 1)
 
         self.optimizer = torch.optim.Adam(
             model.parameters(),

--- a/src/gnn_ils/training/ils_a2c_strategy.py
+++ b/src/gnn_ils/training/ils_a2c_strategy.py
@@ -137,8 +137,12 @@ class ILSA2CStrategy:
         returns_t = torch.tensor(returns, dtype=torch.float32, device=self.device)
 
         last_loss_components = None
+        first_loss_components = None
 
-        for ppo_epoch in range(self.ppo_update_epochs):
+        # Warm-up 中は Critic only なので多回更新不要
+        update_epochs = 1 if self.current_epoch < self.warmup_epochs else self.ppo_update_epochs
+
+        for ppo_epoch in range(update_epochs):
             # 現在のポリシーで re-forward
             (log_probs_l1_new, log_probs_l2_new,
              entropies_l1, entropies_l2, state_values) = self._recompute_log_probs_and_values(trajectory)
@@ -156,7 +160,14 @@ class ILSA2CStrategy:
                 torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.grad_clip_norm)
             self.optimizer.step()
 
+            if first_loss_components is None:
+                first_loss_components = loss_components
             last_loss_components = loss_components
+
+        # 初回と最終の ratio を比較できるようにする
+        if update_epochs > 1 and first_loss_components is not None:
+            last_loss_components['ratio_l1_mean_first'] = first_loss_components.get('ratio_l1_mean', 0.0)
+            last_loss_components['ratio_l2_mean_first'] = first_loss_components.get('ratio_l2_mean', 0.0)
 
         return self._build_train_metrics(trajectory, last_loss_components)
 
@@ -417,20 +428,24 @@ class ILSA2CStrategy:
         entropy_l1_mean = entropies_l1.mean()
         entropy_l2_mean = entropies_l2.mean()
 
-        # Warm-up: Actor 損失を無効化
+        # Warm-up: Actor 損失 + エントロピー項を無効化 (Critic only)
         if is_warmup:
             actor_l1_loss_effective = torch.tensor(0.0, device=self.device)
             actor_l2_loss_effective = torch.tensor(0.0, device=self.device)
+            entropy_l1_effective = torch.tensor(0.0, device=self.device)
+            entropy_l2_effective = torch.tensor(0.0, device=self.device)
         else:
             actor_l1_loss_effective = actor_l1_loss
             actor_l2_loss_effective = actor_l2_loss
+            entropy_l1_effective = entropy_l1_mean
+            entropy_l2_effective = entropy_l2_mean
 
         total_loss = (
             actor_l1_loss_effective
             + actor_l2_loss_effective
             + self.value_loss_weight * critic_loss
-            - self.entropy_weight_l1 * entropy_l1_mean
-            - self.entropy_weight_l2 * entropy_l2_mean
+            - self.entropy_weight_l1 * entropy_l1_effective
+            - self.entropy_weight_l2 * entropy_l2_effective
         )
 
         # 診断メトリクス
@@ -450,6 +465,8 @@ class ILSA2CStrategy:
             'is_warmup': is_warmup,
             'ratio_l1_mean': ratio_l1.mean().item(),
             'ratio_l2_mean': ratio_l2.mean().item(),
+            'ratio_l1_max': ratio_l1.max().item(),
+            'ratio_l2_max': ratio_l2.max().item(),
             'clip_frac_l1': clip_frac_l1,
             'clip_frac_l2': clip_frac_l2,
         }
@@ -504,20 +521,24 @@ class ILSA2CStrategy:
         entropy_l1_mean = entropies_l1.mean()
         entropy_l2_mean = entropies_l2.mean()
 
-        # Warm-up: Actor 損失を無効化
+        # Warm-up: Actor 損失 + エントロピー項を無効化 (Critic only)
         if is_warmup:
             actor_l1_loss_effective = torch.tensor(0.0, device=self.device)
             actor_l2_loss_effective = torch.tensor(0.0, device=self.device)
+            entropy_l1_effective = torch.tensor(0.0, device=self.device)
+            entropy_l2_effective = torch.tensor(0.0, device=self.device)
         else:
             actor_l1_loss_effective = actor_l1_loss
             actor_l2_loss_effective = actor_l2_loss
+            entropy_l1_effective = entropy_l1_mean
+            entropy_l2_effective = entropy_l2_mean
 
         total_loss = (
             actor_l1_loss_effective
             + actor_l2_loss_effective
             + self.value_loss_weight * critic_loss
-            - self.entropy_weight_l1 * entropy_l1_mean
-            - self.entropy_weight_l2 * entropy_l2_mean
+            - self.entropy_weight_l1 * entropy_l1_effective
+            - self.entropy_weight_l2 * entropy_l2_effective
         )
 
         l1_params = list(self.model.commodity_selector.commodity_mlp.parameters())

--- a/src/gnn_ils/training/trainer.py
+++ b/src/gnn_ils/training/trainer.py
@@ -88,6 +88,8 @@ class GNNILSTrainer:
             'train_ratio_l2_mean': [],
             'train_clip_frac_l1': [],
             'train_clip_frac_l2': [],
+            'train_ratio_l1_max': [],
+            'train_ratio_l2_max': [],
             'val_load_factor': [],
             'val_improvement': [],
             'val_num_iterations': [],
@@ -259,6 +261,8 @@ class GNNILSTrainer:
             'ratio_l2_mean': [],
             'clip_frac_l1': [],
             'clip_frac_l2': [],
+            'ratio_l1_max': [],
+            'ratio_l2_max': [],
             'mean_reward': [],
             'final_load_factor': [],
             'improvement': [],
@@ -268,6 +272,10 @@ class GNNILSTrainer:
         }
 
         self.strategy.set_epoch(epoch)
+
+        warmup_epochs = self.config.get('warmup_epochs', 0)
+        if epoch < warmup_epochs:
+            print(f"  [Warm-up {epoch + 1}/{warmup_epochs}] Critic only")
 
         dataset_iter = iter(train_loader)
 
@@ -411,6 +419,8 @@ class GNNILSTrainer:
         self.training_history['train_ratio_l2_mean'].append(train_metrics.get('ratio_l2_mean', 0.0))
         self.training_history['train_clip_frac_l1'].append(train_metrics.get('clip_frac_l1', 0.0))
         self.training_history['train_clip_frac_l2'].append(train_metrics.get('clip_frac_l2', 0.0))
+        self.training_history['train_ratio_l1_max'].append(train_metrics.get('ratio_l1_max', 0.0))
+        self.training_history['train_ratio_l2_max'].append(train_metrics.get('ratio_l2_max', 0.0))
         self.training_history['learning_rate'].append(lr)
         self.training_history['epoch_times'].append(epoch_time)
 
@@ -530,9 +540,9 @@ class GNNILSTrainer:
             diag_header = (f"{'Epoch':<8}{'ActorL1':<10}{'ActorL2':<10}{'CriticL':<10}"
                            f"{'EntL1':<8}{'EntL2':<8}{'AdvMean':<10}{'AdvStd':<10}"
                            f"{'GradL1':<10}{'GradL2':<10}"
-                           f"{'RatL1':<8}{'RatL2':<8}{'ClpL1':<8}{'ClpL2':<8}\n")
+                           f"{'RatL1':<8}{'RatL2':<8}{'RmxL1':<8}{'RmxL2':<8}{'ClpL1':<8}{'ClpL2':<8}\n")
             f.write(diag_header)
-            f.write("-" * 126 + "\n")
+            f.write("-" * 142 + "\n")
 
             def _h(key, i): return self.training_history[key][i] if i < len(self.training_history[key]) else 0.0
 
@@ -550,11 +560,13 @@ class GNNILSTrainer:
                     f"{_h('train_grad_norm_l2',  i):<10.4f}"
                     f"{_h('train_ratio_l1_mean', i):<8.4f}"
                     f"{_h('train_ratio_l2_mean', i):<8.4f}"
+                    f"{_h('train_ratio_l1_max',  i):<8.4f}"
+                    f"{_h('train_ratio_l2_max',  i):<8.4f}"
                     f"{_h('train_clip_frac_l1',  i):<8.4f}"
                     f"{_h('train_clip_frac_l2',  i):<8.4f}\n"
                 )
 
-            f.write("-" * 126 + "\n")
+            f.write("-" * 142 + "\n")
             f.write("\n")
 
             # Detailed val epoch results table

--- a/src/gnn_ils/training/trainer.py
+++ b/src/gnn_ils/training/trainer.py
@@ -42,7 +42,7 @@ class GNNILSTrainer:
         print(f"  - max_iterations:    {config.get('max_iterations', 50)}")
         if use_ppo:
             print(f"  - ppo_clip_eps:      {config.get('ppo_clip_eps', 0.2)}")
-            print(f"  - ppo_update_epochs: {config.get('ppo_update_epochs', 4)}")
+            print(f"  - ppo_update_epochs: {config.get('ppo_update_epochs', 1)}")
         warmup = config.get('warmup_epochs', 0)
         if warmup > 0:
             print(f"  - warmup_epochs:     {warmup}")

--- a/src/gnn_ils/training/trainer.py
+++ b/src/gnn_ils/training/trainer.py
@@ -33,11 +33,22 @@ class GNNILSTrainer:
         self.model = self._instantiate_model()
         self.strategy = ILSA2CStrategy(self.model, config)
 
-        print(f"✓ Using 2-Level A2C Training Strategy (GNN-ILS)")
+        use_ppo = config.get('use_ppo', False)
+        algo_name = "PPO" if use_ppo else "A2C"
+        print(f"✓ Using 2-Level {algo_name} Training Strategy (GNN-ILS)")
         print(f"  - entropy_weight_l1: {config.get('entropy_weight_l1', 0.02)}")
         print(f"  - entropy_weight_l2: {config.get('entropy_weight_l2', 0.01)}")
         print(f"  - value_loss_weight: {config.get('value_loss_weight', 0.5)}")
         print(f"  - max_iterations:    {config.get('max_iterations', 50)}")
+        if use_ppo:
+            print(f"  - ppo_clip_eps:      {config.get('ppo_clip_eps', 0.2)}")
+            print(f"  - ppo_update_epochs: {config.get('ppo_update_epochs', 4)}")
+        warmup = config.get('warmup_epochs', 0)
+        if warmup > 0:
+            print(f"  - warmup_epochs:     {warmup}")
+        bias_init = config.get('value_head_bias_init', 0.0)
+        if bias_init != 0.0:
+            print(f"  - value_head_bias:   {bias_init}")
 
         checkpoint_dir_cfg = config.get('checkpoint_dir')
         if checkpoint_dir_cfg:
@@ -73,6 +84,10 @@ class GNNILSTrainer:
             'train_critic_loss': [],
             'train_advantage_mean': [],
             'train_advantage_std': [],
+            'train_ratio_l1_mean': [],
+            'train_ratio_l2_mean': [],
+            'train_clip_frac_l1': [],
+            'train_clip_frac_l2': [],
             'val_load_factor': [],
             'val_improvement': [],
             'val_num_iterations': [],
@@ -240,6 +255,10 @@ class GNNILSTrainer:
             'grad_norm_l2': [],
             'advantage_mean': [],
             'advantage_std': [],
+            'ratio_l1_mean': [],
+            'ratio_l2_mean': [],
+            'clip_frac_l1': [],
+            'clip_frac_l2': [],
             'mean_reward': [],
             'final_load_factor': [],
             'improvement': [],
@@ -247,6 +266,8 @@ class GNNILSTrainer:
             'approximation_ratio': [],
             'best_iteration': [],
         }
+
+        self.strategy.set_epoch(epoch)
 
         dataset_iter = iter(train_loader)
 
@@ -386,6 +407,10 @@ class GNNILSTrainer:
         self.training_history['train_critic_loss'].append(train_metrics.get('critic_loss', 0.0))
         self.training_history['train_advantage_mean'].append(train_metrics.get('advantage_mean', 0.0))
         self.training_history['train_advantage_std'].append(train_metrics.get('advantage_std', 0.0))
+        self.training_history['train_ratio_l1_mean'].append(train_metrics.get('ratio_l1_mean', 0.0))
+        self.training_history['train_ratio_l2_mean'].append(train_metrics.get('ratio_l2_mean', 0.0))
+        self.training_history['train_clip_frac_l1'].append(train_metrics.get('clip_frac_l1', 0.0))
+        self.training_history['train_clip_frac_l2'].append(train_metrics.get('clip_frac_l2', 0.0))
         self.training_history['learning_rate'].append(lr)
         self.training_history['epoch_times'].append(epoch_time)
 
@@ -504,9 +529,10 @@ class GNNILSTrainer:
             f.write("=" * 50 + "\n")
             diag_header = (f"{'Epoch':<8}{'ActorL1':<10}{'ActorL2':<10}{'CriticL':<10}"
                            f"{'EntL1':<8}{'EntL2':<8}{'AdvMean':<10}{'AdvStd':<10}"
-                           f"{'GradL1':<10}{'GradL2':<10}\n")
+                           f"{'GradL1':<10}{'GradL2':<10}"
+                           f"{'RatL1':<8}{'RatL2':<8}{'ClpL1':<8}{'ClpL2':<8}\n")
             f.write(diag_header)
-            f.write("-" * 94 + "\n")
+            f.write("-" * 126 + "\n")
 
             def _h(key, i): return self.training_history[key][i] if i < len(self.training_history[key]) else 0.0
 
@@ -521,10 +547,14 @@ class GNNILSTrainer:
                     f"{_h('train_advantage_mean',i):<10.4f}"
                     f"{_h('train_advantage_std', i):<10.4f}"
                     f"{_h('train_grad_norm_l1',  i):<10.4f}"
-                    f"{_h('train_grad_norm_l2',  i):<10.4f}\n"
+                    f"{_h('train_grad_norm_l2',  i):<10.4f}"
+                    f"{_h('train_ratio_l1_mean', i):<8.4f}"
+                    f"{_h('train_ratio_l2_mean', i):<8.4f}"
+                    f"{_h('train_clip_frac_l1',  i):<8.4f}"
+                    f"{_h('train_clip_frac_l2',  i):<8.4f}\n"
                 )
 
-            f.write("-" * 94 + "\n")
+            f.write("-" * 126 + "\n")
             f.write("\n")
 
             # Detailed val epoch results table


### PR DESCRIPTION
## Summary

GNN-ILS の学習安定性を改善する3つの施策を実装:

- **改善A: Value Head バイアス初期化** — Critic の出力バイアスを `-2.0` で初期化し、V(s) が報酬スケールに近い値からスタートするようにする。Advantage の初期偏りを軽減
- **改善B: Critic Warm-up** — 最初の `warmup_epochs` エポック間は Actor 損失を無効化し、Critic のみを学習させる。V(s) が安定してから Actor を更新開始
- **改善C: PPO クリッピング** — `use_ppo=true` で有効化。クリップされた surrogate objective で複数回更新し、大きな方策更新による急激退行を防止

## 変更内容

| ファイル | 変更 |
|---|---|
| `value_head.py` | `bias_init_value` 引数追加、MLP最終層バイアス初期化 |
| `gnn_ils_model.py` | config → value_head に `bias_init_value` を渡す |
| `ils_a2c_strategy.py` | Warm-up / PPO loss / re-forward / `train_step` 分岐 |
| `trainer.py` | `set_epoch()` 呼び出し、PPO診断ログ追加 |
| `gnn_ils_base.json` | 新規configキー追加 |
| `gnn_ils_nsfnet.json` | 同上 |

## Config 新規キー

```json
"value_head_bias_init": -2.0,
"warmup_epochs": 3,
"use_ppo": false,
"ppo_clip_eps": 0.2,
"ppo_update_epochs": 4
```

## Test plan

- [ ] デフォルト config (`use_ppo: false`) で既存 A2C と同一挙動を確認
- [ ] `value_head_bias_init: -2.0` でバイアスが正しく初期化されることを確認
- [ ] Warm-up 中の `actor_l1_loss == 0.0`, `actor_l2_loss == 0.0` を確認
- [ ] `use_ppo: true` で PPO ratio, clip_fraction が健全な範囲にあることを確認
- [ ] 小規模データで数 epoch 学習し loss が発散しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)