### PR TITLE
refactor: GNN-ILS MLPヘッドを漏斗型アーキテクチャに改善

### DIFF
--- a/configs/gnn_ils/gnn_ils_base.json
+++ b/configs/gnn_ils/gnn_ils_base.json
@@ -27,8 +27,8 @@
     "dropout_rate": 0.3,
 
     "_comment_selector": "=== Selector Networks ===",
-    "commodity_selector_mlp_layers": 2,
-    "path_selector_mlp_layers": 2,
+    "commodity_selector_mlp_layers": 3,
+    "path_selector_mlp_layers": 3,
     "value_head_mlp_layers": 3,
     "use_graph_embedding_value": true,
 

--- a/configs/gnn_ils/gnn_ils_nsfnet.json
+++ b/configs/gnn_ils/gnn_ils_nsfnet.json
@@ -27,8 +27,8 @@
     "dropout_rate": 0.3,
 
     "_comment_selector": "=== Selector Networks ===",
-    "commodity_selector_mlp_layers": 2,
-    "path_selector_mlp_layers": 2,
+    "commodity_selector_mlp_layers": 3,
+    "path_selector_mlp_layers": 3,
     "value_head_mlp_layers": 3,
     "use_graph_embedding_value": true,
 

--- a/src/gnn_ils/models/commodity_selector.py
+++ b/src/gnn_ils/models/commodity_selector.py
@@ -25,7 +25,13 @@ class CommoditySelector(nn.Module):
         self.hidden_dim = hidden_dim
         self.num_commodities = num_commodities
 
-        hidden_dims = [128] * (mlp_layers - 1)
+        # 漏斗型: 入力次元に近い層から段階的に絞る
+        if mlp_layers >= 3:
+            hidden_dims = [128, 64][:mlp_layers - 1]
+        elif mlp_layers == 2:
+            hidden_dims = [128]
+        else:
+            hidden_dims = []
         self.commodity_mlp = MLP(
             hidden_dim + 1,
             1,

--- a/src/gnn_ils/models/path_selector.py
+++ b/src/gnn_ils/models/path_selector.py
@@ -28,7 +28,13 @@ class PathSelector(nn.Module):
         self.max_paths = max_paths
         self.path_aggregation = path_aggregation
 
-        hidden_dims = [128] * (mlp_layers - 1)
+        # 漏斗型: 入力次元(2H+1)に近い層から段階的に絞る
+        if mlp_layers >= 3:
+            hidden_dims = [hidden_dim * 2, 64][:mlp_layers - 1]
+        elif mlp_layers == 2:
+            hidden_dims = [hidden_dim * 2]
+        else:
+            hidden_dims = []
         self.path_score_mlp = MLP(
             hidden_dim * 2 + 1,
             1,

--- a/src/gnn_ils/models/path_selector.py
+++ b/src/gnn_ils/models/path_selector.py
@@ -32,7 +32,8 @@ class PathSelector(nn.Module):
         if mlp_layers >= 3:
             hidden_dims = [hidden_dim * 2, 64][:mlp_layers - 1]
         elif mlp_layers == 2:
-            hidden_dims = [hidden_dim * 2]
+            # 従来は [128] (257→128→1) だが漏斗型原則に合わせて変更。後方互換なし
+            hidden_dims = [128]
         else:
             hidden_dims = []
         self.path_score_mlp = MLP(

--- a/src/gnn_ils/models/value_head.py
+++ b/src/gnn_ils/models/value_head.py
@@ -30,11 +30,12 @@ class ILSValueHead(nn.Module):
         self.use_graph_embedding = use_graph_embedding
 
         if use_graph_embedding:
+            # 漏斗型: 128 → 128 → 64 → 1
             input_dim = hidden_dim
             if mlp_layers >= 3:
-                hidden_dims = [256, 128][:mlp_layers - 1]
+                hidden_dims = [128, 64][:mlp_layers - 1]
             elif mlp_layers == 2:
-                hidden_dims = [128]
+                hidden_dims = [64]
             else:
                 hidden_dims = []
         else:


### PR DESCRIPTION
## Summary

GNN-ILS の3つの MLP ヘッド（CommoditySelector / PathSelector / ValueHead）のアーキテクチャを改善。

- **PathSelector のボトルネック解消**: 入力257次元を128に圧縮していた第1隠れ層を256に拡大
- **急激な次元削減の解消**: 全ヘッドで出力前に64次元の中間層を挿入し、128→1 の急激削減を回避
- **ValueHead の無意味な拡張削除**: 128→256→128→1 の拡張→縮小パターンを 128→128→64→1 の単調減少に変更

## 変更前後

| ヘッド | 変更前 | 変更後 | パラメータ |
|---|---|---|---|
| CommoditySelector | 129→128→1 (2層) | 129→128→64→1 (3層) | 16,769 → 24,961 |
| PathSelector | 257→128→1 (2層) | 257→256→64→1 (3層) | 33,153 → 82,561 |
| ValueHead (graph_emb) | 128→256→128→1 (3層) | 128→128→64→1 (3層) | 66,049 → 24,833 |
| **ヘッド合計** | **115,971** | **132,355** | **+14%** |

## Test plan

- [ ] 両 config でモデルが正しくインスタンス化されることを確認
- [ ] 各 MLP の hidden_dims が期待通りの漏斗型であることを確認
- [ ] 小規模データで学習が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)