### PR TITLE
feat: GNN-ILS テスト時のサンプル単位計算時間計測を追加

### DIFF
--- a/scripts/gnn_ils/test_gnn_ils.py
+++ b/scripts/gnn_ils/test_gnn_ils.py
@@ -59,6 +59,10 @@ def main():
             print(f"  Approx Ratio:       {test_metrics['approximation_ratio']:.2f}%")
         else:
             print(f"  Approx Ratio:       N/A")
+        print(f"  ---")
+        print(f"  Total Time:         {test_metrics.get('total_time', 0):.2f}s")
+        print(f"  Mean Time/Sample:   {test_metrics.get('mean_time_per_sample', 0):.4f}s")
+        print(f"  Std  Time/Sample:   {test_metrics.get('std_time_per_sample', 0):.4f}s")
     else:
         print("  No test results.")
     print(f"{'='*70}\n")

--- a/src/gnn_ils/training/trainer.py
+++ b/src/gnn_ils/training/trainer.py
@@ -334,6 +334,7 @@ class GNNILSTrainer:
             'approximation_ratio': [],
             'best_iteration': [],
         }
+        sample_times: list = []
 
         dataset_iter = iter(val_loader)
 
@@ -349,7 +350,9 @@ class GNNILSTrainer:
                 for k, v in batch_data.items()
             }
 
+            sample_start = time.time()
             metrics = self.strategy.eval_step(batch_data)
+            sample_times.append(time.time() - sample_start)
 
             for key in epoch_metrics:
                 if key in metrics and metrics[key] is not None:
@@ -371,6 +374,9 @@ class GNNILSTrainer:
         avg['mean_load_factor'] = avg.get('final_load_factor', 0.0)
         avg['complete_rate'] = 100.0
         avg['complete_sample_rate'] = 100.0
+        avg['mean_time_per_sample'] = float(np.mean(sample_times)) if sample_times else 0.0
+        avg['std_time_per_sample'] = float(np.std(sample_times)) if sample_times else 0.0
+        avg['total_time'] = float(np.sum(sample_times)) if sample_times else 0.0
         return avg
 
     def _log_epoch(self, epoch, train_metrics, val_metrics, lr, epoch_time):


### PR DESCRIPTION
## Summary

- `_validate_epoch` 内で各サンプル（シナリオ）の `eval_step` 実行時間を計測
- テスト結果に Total Time / Mean Time/Sample / Std Time/Sample を表示
- 1シナリオあたりの平均計算時間を把握できるように

## 変更ファイル

- `src/gnn_ils/training/trainer.py` — `_validate_epoch` にサンプル単位の時間計測を追加
- `scripts/gnn_ils/test_gnn_ils.py` — テスト結果の出力に計測結果を追加

## Test plan

- [ ] `python scripts/gnn_ils/test_gnn_ils.py --config <config>` を実行し、計測結果が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)