### PR TITLE
fix: perturbation の patience 無効化問題を修正し、コード品質を改善

### DIFF
--- a/src/gnn_ils/environment/ils_environment.py
+++ b/src/gnn_ils/environment/ils_environment.py
@@ -43,6 +43,7 @@ class ILSEnvironment:
         self.max_iterations = config.get('max_iterations', 50)
         self.no_improve_patience = config.get('no_improve_patience', 10)
         self.perturbation_prob = config.get('perturbation_prob', 0.1)
+        self.max_perturbations = config.get('max_perturbations', 3)
         self.max_candidate_paths = config.get('max_candidate_paths', 15)
         self.reward_mode = config.get('reward_mode', 'shared')
         self.reward_scale = config.get('reward_scale', 100.0)
@@ -67,6 +68,7 @@ class ILSEnvironment:
         self.best_load_factor: float = float('inf')
         self.best_assignment: List[List[int]] = []
         self.best_iteration: int = 0
+        self.perturbation_count: int = 0
 
     def reset(
         self,
@@ -109,6 +111,7 @@ class ILSEnvironment:
         # カウンタ初期化
         self.iteration = 0
         self.no_improve_count = 0
+        self.perturbation_count = 0
 
         # Best-so-far を初期状態で初期化
         self.best_load_factor = self.current_load_factor
@@ -265,10 +268,8 @@ class ILSEnvironment:
         Returns:
             リルートが発生したか
         """
-        # 現在の edge_usage を計算
-        usage_np = compute_edge_usage(
-            self.current_assignment, self.commodity_list, self.num_nodes
-        )
+        # 既存の edge_usage テンソルを流用（直前の env.step() で更新済み）
+        usage_np = self.x_edges_usage[0].numpy()
 
         # ボトルネックリンクの特定: usage / capacity が最大の (u, v)
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -336,21 +337,27 @@ class ILSEnvironment:
 
         return rerouted
 
-    def apply_perturbation(self) -> None:
+    def apply_perturbation(self) -> Dict:
         """
         Perturbation を適用し、no_improve_count をリセットする。
 
         - best_load_factor の更新は行わない（悪化しても best は保持）
         - iteration カウンタはインクリメントしない
+
+        Returns:
+            perturbation 後の状態辞書
         """
         self.perturbation_congestion_aware()
         self.no_improve_count = 0
+        self.perturbation_count += 1
+        return self._build_state()
 
     def should_perturb(self) -> bool:
-        """改善停滞時かつ探索途中なら True を返す。"""
+        """改善停滞時かつ探索途中かつ perturbation 上限未到達なら True を返す。"""
         return (
             self.no_improve_count >= self.no_improve_patience // 2
             and self.iteration < self.max_iterations
+            and self.perturbation_count < self.max_perturbations
         )
 
     def _build_state(self) -> Dict:

--- a/src/gnn_ils/training/ils_a2c_strategy.py
+++ b/src/gnn_ils/training/ils_a2c_strategy.py
@@ -304,8 +304,7 @@ class ILSA2CStrategy:
 
             # Perturbation チェック: RL学習対象外（報酬・log_prob を記録しない）
             if not done and self.env.should_perturb():
-                self.env.apply_perturbation()
-                state = self.env._build_state()  # perturbation 後の状態を取得
+                state = self.env.apply_perturbation()
 
         trajectory['final_load_factor'] = state['load_factor']
 

--- a/tests/test_perturbation.py
+++ b/tests/test_perturbation.py
@@ -1,6 +1,5 @@
 import pytest
 import random
-import copy
 
 import networkx as nx
 import numpy as np
@@ -42,6 +41,7 @@ def _make_config(**overrides):
         'max_iterations': 50,
         'no_improve_patience': 10,
         'perturbation_prob': 0.3,
+        'max_perturbations': 3,
         'K': 5,
         'max_disjoint': 3,
         'max_candidate_paths': 10,
@@ -97,10 +97,7 @@ class TestPerturbationCongestionAware:
         env, _ = _setup_env(config=config)
 
         # ボトルネックを手動で作成: commodity 0 を 0->1->4 に設定
-        # エッジ (0,1) に demand=5 が集中するようにする
-        bottleneck_path = [0, 1, 4]
-        env.current_assignment[0] = bottleneck_path
-
+        env.current_assignment[0] = [0, 1, 4]
         # commodity 1 も 0->1->3 を通らせて (0,1) に更に負荷をかける
         env.current_assignment[1] = [0, 1, 3]
 
@@ -123,7 +120,6 @@ class TestPerturbationCongestionAware:
 
         assignment_before = [list(p) for p in env.current_assignment]
 
-        # perturbation 実行
         rerouted = env.perturbation_congestion_aware()
 
         assert rerouted, "perturbation_prob=1.0 でリルートが発生しなかった"
@@ -133,7 +129,6 @@ class TestPerturbationCongestionAware:
         for c_idx in range(len(env.current_assignment)):
             if env.current_assignment[c_idx] != assignment_before[c_idx]:
                 changed = True
-                # 新しいパスがボトルネックリンクを含まないことを確認
                 new_path = env.current_assignment[c_idx]
                 for i in range(len(new_path) - 1):
                     edge = (new_path[i], new_path[i + 1])
@@ -146,8 +141,7 @@ class TestPerturbationCongestionAware:
 
     def test_perturbation_prob_zero_triggers_fallback(self):
         """
-        perturbation_prob=0.0 の場合、全 commodity がスキップされるが、
-        フォールバックで少なくとも1本は変更されることを確認する。
+        perturbation_prob=0.0 の場合、フォールバックで少なくとも1本は変更される。
         """
         random.seed(42)
         np.random.seed(42)
@@ -156,12 +150,9 @@ class TestPerturbationCongestionAware:
         env, _ = _setup_env(config=config)
 
         assignment_before = [list(p) for p in env.current_assignment]
-
         rerouted = env.perturbation_congestion_aware()
 
         assert rerouted, "フォールバックでリルートが発生しなかった"
-
-        # 少なくとも1箇所異なることを確認
         any_changed = any(
             env.current_assignment[c] != assignment_before[c]
             for c in range(len(env.current_assignment))
@@ -170,33 +161,27 @@ class TestPerturbationCongestionAware:
 
     def test_perturbation_guarantees_at_least_one_change(self):
         """
-        任意の設定で perturbation_congestion_aware() を10回呼び、
-        毎回少なくとも1つの commodity のパスが変わることを確認する。
+        10回呼び、毎回少なくとも1つの commodity のパスが変わることを確認する。
         """
         for trial in range(10):
             random.seed(trial)
             np.random.seed(trial)
 
             env, _ = _setup_env()
-
             assignment_before = [list(p) for p in env.current_assignment]
 
             rerouted = env.perturbation_congestion_aware()
 
             assert rerouted, f"trial {trial}: perturbation がリルートを返さなかった"
-
             any_changed = any(
                 env.current_assignment[c] != assignment_before[c]
                 for c in range(len(env.current_assignment))
             )
-            assert any_changed, (
-                f"trial {trial}: perturbation 後にパスが1つも変わっていない"
-            )
+            assert any_changed, f"trial {trial}: perturbation 後にパスが1つも変わっていない"
 
     def test_perturbation_does_not_select_current_path(self):
         """
-        perturbation_prob=1.0 で代替パスがある commodity について、
-        perturbation 後のパスが perturbation 前と同じでないことを確認する。
+        perturbation_prob=1.0 で変更された commodity のパスがボトルネックを含まないことを確認する。
         """
         random.seed(42)
         np.random.seed(42)
@@ -204,40 +189,26 @@ class TestPerturbationCongestionAware:
         config = _make_config(perturbation_prob=1.0)
         env, _ = _setup_env(config=config)
 
-        # ボトルネックを手動で作成: commodity 0 を 0->1->4 に設定
-        # commodity 1 も 0->1->3 にして (0,1) に負荷集中
         env.current_assignment[0] = [0, 1, 4]
         env.current_assignment[1] = [0, 1, 3]
 
-        # 再計算
         usage_np = compute_edge_usage(
             env.current_assignment, env.commodity_list, env.num_nodes
         )
         env.x_edges_usage = torch.tensor(usage_np, dtype=torch.float32).unsqueeze(0)
         env.current_load_factor = compute_load_factor(usage_np, env.capacity_np)
 
-        # ボトルネックリンクを特定
         with np.errstate(divide='ignore', invalid='ignore'):
-            load_ratio = np.where(
-                env.capacity_np > 0,
-                usage_np / env.capacity_np,
-                0.0,
-            )
+            load_ratio = np.where(env.capacity_np > 0, usage_np / env.capacity_np, 0.0)
         bn_idx = np.unravel_index(np.argmax(load_ratio), load_ratio.shape)
         bn_u, bn_v = int(bn_idx[0]), int(bn_idx[1])
 
         assignment_before = [tuple(p) for p in env.current_assignment]
-
         env.perturbation_congestion_aware()
 
-        # パスが変わった commodity について、変更後のパスが変更前と異なることを確認
-        # (perturbation はボトルネックを回避する代替パスがある commodity のみ変更する)
         for c_idx in range(len(env.current_assignment)):
             current_tuple = tuple(env.current_assignment[c_idx])
             if current_tuple != assignment_before[c_idx]:
-                # 変更された commodity のパスは、元のパスと異なるはず (tautology だが明示)
-                assert current_tuple != assignment_before[c_idx]
-                # さらに、新しいパスがボトルネックリンクを含まないことを確認
                 new_path = env.current_assignment[c_idx]
                 for i in range(len(new_path) - 1):
                     edge = (new_path[i], new_path[i + 1])
@@ -247,14 +218,52 @@ class TestPerturbationCongestionAware:
                         f"({bn_u},{bn_v}) が含まれている: {new_path}"
                     )
 
-        # 少なくとも1つは変更されているはず (prob=1.0)
         any_changed = any(
             tuple(env.current_assignment[c]) != assignment_before[c]
             for c in range(len(env.current_assignment))
         )
-        assert any_changed, (
-            "perturbation_prob=1.0 で1つも commodity のパスが変わらなかった"
+        assert any_changed, "perturbation_prob=1.0 で1つも commodity のパスが変わらなかった"
+
+    def test_perturbation_no_alternatives_fallback(self):
+        """
+        全対象 commodity で代替パスが構造的に存在しない場合、
+        フォールバックでボトルネックと無関係な commodity がリルートされることを確認する。
+        """
+        random.seed(42)
+
+        G = nx.DiGraph()
+        G.add_edge(0, 1, weight=1.0, capacity=5.0)
+        G.add_edge(1, 2, weight=1.0, capacity=5.0)
+        G.add_edge(0, 2, weight=1.0, capacity=10.0)
+        G.add_edge(2, 0, weight=1.0, capacity=10.0)
+        G.add_edge(1, 0, weight=1.0, capacity=10.0)
+        G.add_edge(2, 1, weight=1.0, capacity=10.0)
+
+        commodities = [[0, 2, 10], [0, 1, 1]]
+        config = _make_config(
+            num_nodes=3, num_commodities=2,
+            perturbation_prob=1.0, K=3, max_disjoint=2, max_candidate_paths=5,
         )
+        env = ILSEnvironment(config)
+
+        V, C = 3, 2
+        x_nodes = torch.zeros(1, V, C, dtype=torch.long)
+        x_commodities = torch.tensor([commodities], dtype=torch.float32)
+        x_edges_capacity = torch.zeros(1, V, V, dtype=torch.float32)
+        for u, v, data in G.edges(data=True):
+            x_edges_capacity[0, u, v] = data['capacity']
+
+        env.reset(G, commodities, x_nodes, x_commodities, x_edges_capacity)
+
+        assignment_before = [list(p) for p in env.current_assignment]
+        rerouted = env.perturbation_congestion_aware()
+
+        assert rerouted, "フォールバックでリルートが発生しなかった"
+        any_changed = any(
+            env.current_assignment[c] != assignment_before[c]
+            for c in range(len(env.current_assignment))
+        )
+        assert any_changed, "代替パスなしケースでフォールバックが動作しなかった"
 
 
 # ---------------------------------------------------------------------------
@@ -270,44 +279,39 @@ class TestILSLoopIntegration:
         - no_improve_count=4 -> False
         - no_improve_count=5 -> True
         - iteration=max_iterations -> False (上限到達)
+        - perturbation_count=max_perturbations -> False (上限到達)
         """
         random.seed(42)
-        config = _make_config(no_improve_patience=10, max_iterations=50)
+        config = _make_config(no_improve_patience=10, max_iterations=50, max_perturbations=3)
         env, _ = _setup_env(config=config)
 
-        # patience // 2 = 5 が閾値
         env.no_improve_count = 4
-        assert env.should_perturb() is False, "no_improve_count=4 で should_perturb() が True になった"
+        assert env.should_perturb() is False
 
         env.no_improve_count = 5
-        assert env.should_perturb() is True, "no_improve_count=5 で should_perturb() が False になった"
+        assert env.should_perturb() is True
 
-        # iteration が max_iterations に達している場合は False
         env.no_improve_count = 5
         env.iteration = env.max_iterations
-        assert env.should_perturb() is False, "iteration=max_iterations で should_perturb() が True になった"
+        assert env.should_perturb() is False
+
+        env.iteration = 10
+        env.no_improve_count = 5
+        env.perturbation_count = 3
+        assert env.should_perturb() is False
 
     def test_apply_perturbation_resets_counter(self):
-        """
-        apply_perturbation() が no_improve_count を 0 にリセットすることを確認する。
-        """
+        """apply_perturbation() が no_improve_count を 0 にリセットする。"""
         random.seed(42)
         env, _ = _setup_env()
 
         env.no_improve_count = 5
-        assert env.no_improve_count == 5
-
         env.apply_perturbation()
 
-        assert env.no_improve_count == 0, (
-            f"apply_perturbation() 後に no_improve_count が 0 にリセットされなかった: "
-            f"{env.no_improve_count}"
-        )
+        assert env.no_improve_count == 0
 
     def test_apply_perturbation_preserves_best(self):
-        """
-        apply_perturbation() が best_load_factor を変えないことを確認する。
-        """
+        """apply_perturbation() が best_load_factor を変えない。"""
         random.seed(42)
         env, _ = _setup_env()
 
@@ -316,43 +320,58 @@ class TestILSLoopIntegration:
 
         env.apply_perturbation()
 
-        assert env.best_load_factor == best_lf_before, (
-            f"apply_perturbation() が best_load_factor を変更した: "
-            f"{best_lf_before} -> {env.best_load_factor}"
-        )
-        assert env.best_assignment == best_assignment_before, (
-            "apply_perturbation() が best_assignment を変更した"
-        )
+        assert env.best_load_factor == best_lf_before
+        assert env.best_assignment == best_assignment_before
 
     def test_perturbation_updates_internal_state(self):
-        """
-        apply_perturbation() の前後で x_edges_usage と current_load_factor が
-        再計算されていることを確認する。
-        """
+        """apply_perturbation() 後に内部状態が assignment と整合する。"""
         random.seed(42)
         env, _ = _setup_env()
 
-        usage_before = env.x_edges_usage.clone()
-        lf_before = env.current_load_factor
-
         env.apply_perturbation()
 
-        # パスが変わっているなら usage も変わっているはず
-        # (フォールバック含めて必ず1本は変わるので usage は変わる)
-        usage_after = env.x_edges_usage.clone()
-        lf_after = env.current_load_factor
-
-        # 再計算の整合性チェック: 現在の assignment から期待される usage/lf を計算
         expected_usage = compute_edge_usage(
             env.current_assignment, env.commodity_list, env.num_nodes
         )
         expected_lf = compute_load_factor(expected_usage, env.capacity_np)
 
         np.testing.assert_allclose(
-            usage_after[0].numpy(), expected_usage,
-            rtol=1e-5,
-            err_msg="x_edges_usage が current_assignment と整合していない",
+            env.x_edges_usage[0].numpy(), expected_usage, rtol=1e-5,
         )
-        assert abs(lf_after - expected_lf) < 1e-8, (
-            f"current_load_factor が再計算値と一致しない: {lf_after} vs {expected_lf}"
+        assert abs(env.current_load_factor - expected_lf) < 1e-8
+
+    def test_max_perturbations_restores_patience_termination(self):
+        """
+        max_perturbations 回消費後は should_perturb() が False になり、
+        patience による早期終了が有効に戻る。
+        """
+        random.seed(42)
+        config = _make_config(
+            no_improve_patience=10, max_iterations=100, max_perturbations=2
         )
+        env, _ = _setup_env(config=config)
+
+        for _ in range(2):
+            env.no_improve_count = 5
+            assert env.should_perturb() is True
+            env.apply_perturbation()
+
+        assert env.perturbation_count == 2
+        env.no_improve_count = 5
+        assert env.should_perturb() is False
+
+        # patience=10 の done 条件に到達可能
+        env.no_improve_count = 10
+        assert env._check_done() is True
+
+    def test_apply_perturbation_returns_state(self):
+        """apply_perturbation() が状態辞書を返す。"""
+        random.seed(42)
+        env, _ = _setup_env()
+
+        state = env.apply_perturbation()
+
+        assert isinstance(state, dict)
+        assert 'x_edges_usage' in state
+        assert 'load_factor' in state
+        assert 'current_assignment' in state


### PR DESCRIPTION
## Summary

PR #63 で実装した perturbation の以下の問題を修正:

### 1. [Medium] patience による早期終了が無効化されていた
- `max_perturbations` パラメータを追加（デフォルト: 3）
- perturbation 上限到達後は `should_perturb()` が False になり、patience による早期終了が復活
- 5C に perturbation を適用しても、最大3回の perturbation 後は従来通り patience で停止

### 2. [Low] `_build_state()` をクラス外から呼んでいた
- `apply_perturbation()` が `Dict` を返すように変更
- `ils_a2c_strategy.py` から private メソッドの直接呼び出しを除去

### 3. [Low] `compute_edge_usage` の二重計算
- `perturbation_congestion_aware()` 冒頭で既存の `x_edges_usage` テンソルを流用

### 4. [Low] テストの改善
- 未使用の `import copy` を削除
- tautology な assert を削除
- 「全対象 commodity で代替パスなし」のテストを追加
- `max_perturbations` 関連のテスト2件を追加（計11テスト）

## Test plan

- [x] `pytest tests/test_perturbation.py -v` — 全11テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)