### PR TITLE
feat: Return 正規化 (Running Normalization) を実装

### DIFF
--- a/src/gnn_ils/training/ils_a2c_strategy.py
+++ b/src/gnn_ils/training/ils_a2c_strategy.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, List, Tuple
 
 from src.gnn_ils.models.gnn_ils_model import GNNILSModel
 from src.gnn_ils.environment.ils_environment import ILSEnvironment
+from src.gnn_ils.training.return_normalizer import RunningReturnNormalizer
 
 
 class ILSA2CStrategy:
@@ -80,6 +81,12 @@ class ILSA2CStrategy:
 
         self.env = ILSEnvironment(config)
 
+        # Return normalization
+        self.normalize_returns = config.get('normalize_returns', False)
+        self.return_normalizer = RunningReturnNormalizer(
+            momentum=config.get('return_norm_momentum', 0.99),
+        )
+
     def set_epoch(self, epoch: int):
         """現在のエポック番号を設定する (warm-up 判定用)。"""
         self.current_epoch = epoch
@@ -135,6 +142,10 @@ class ILSA2CStrategy:
             R = r + self.gamma * R
             returns.insert(0, R)
         returns_t = torch.tensor(returns, dtype=torch.float32, device=self.device)
+
+        # Return normalization
+        if self.normalize_returns:
+            returns_t = self.return_normalizer.normalize(returns_t)
 
         last_loss_components = None
         first_loss_components = None
@@ -513,6 +524,10 @@ class ILSA2CStrategy:
             R = r + self.gamma * R
             returns.insert(0, R)
         returns_t = torch.tensor(returns, dtype=torch.float32, device=self.device)
+
+        # Return normalization
+        if self.normalize_returns:
+            returns_t = self.return_normalizer.normalize(returns_t)
 
         log_probs_l1 = torch.stack(trajectory['log_probs_l1'])  # [T]
         log_probs_l2 = torch.stack(trajectory['log_probs_l2'])  # [T]

--- a/src/gnn_ils/training/return_normalizer.py
+++ b/src/gnn_ils/training/return_normalizer.py
@@ -1,0 +1,70 @@
+import torch
+
+
+class RunningReturnNormalizer:
+    """
+    Return (discounted cumulative reward) の Running Normalization。
+
+    エピソードをまたいで return の mean/var を指数移動平均で追跡し、
+    各エピソードの return を正規化する。Critic の学習ターゲットを
+    reward_scale に依存しない安定したスケールに保つ。
+
+    使い方:
+        normalizer = RunningReturnNormalizer()
+        returns_t = compute_returns(rewards, gamma)
+        returns_normalized = normalizer.normalize(returns_t)
+        critic_loss = F.mse_loss(state_values, returns_normalized)
+    """
+
+    def __init__(self, momentum: float = 0.99, epsilon: float = 1e-8):
+        """
+        Args:
+            momentum: 指数移動平均の係数。1に近いほど過去の統計を重視。
+                      0.99 = 直近100エピソード程度の統計を反映。
+            epsilon: ゼロ除算防止の微小値。
+        """
+        self.momentum = momentum
+        self.epsilon = epsilon
+        self.running_mean = 0.0
+        self.running_var = 1.0
+        self._initialized = False
+
+    def normalize(self, returns_t: torch.Tensor) -> torch.Tensor:
+        """
+        Return テンソルを正規化する。
+
+        初回呼び出し時はバッチ統計で初期化。以降は指数移動平均で更新。
+
+        Args:
+            returns_t: [T] 形状の return テンソル（1エピソード分）
+
+        Returns:
+            正規化された return テンソル [T]（mean≈0, std≈1）
+        """
+        with torch.no_grad():
+            batch_mean = returns_t.mean().item()
+            batch_var = returns_t.var().item() if returns_t.numel() > 1 else 1.0
+
+            if not self._initialized:
+                self.running_mean = batch_mean
+                self.running_var = max(batch_var, self.epsilon)
+                self._initialized = True
+            else:
+                self.running_mean = (
+                    self.momentum * self.running_mean
+                    + (1.0 - self.momentum) * batch_mean
+                )
+                self.running_var = (
+                    self.momentum * self.running_var
+                    + (1.0 - self.momentum) * batch_var
+                )
+
+        return (returns_t - self.running_mean) / (
+            (self.running_var ** 0.5) + self.epsilon
+        )
+
+    def reset(self):
+        """統計をリセットする（新規学習開始時に使用）。"""
+        self.running_mean = 0.0
+        self.running_var = 1.0
+        self._initialized = False

--- a/tests/test_return_normalizer.py
+++ b/tests/test_return_normalizer.py
@@ -1,0 +1,127 @@
+import pytest
+import torch
+
+from src.gnn_ils.training.return_normalizer import RunningReturnNormalizer
+
+
+class TestRunningReturnNormalizer:
+    """RunningReturnNormalizer のユニットテスト。"""
+
+    def test_first_call_normalizes_to_zero_mean_unit_std(self):
+        """初回呼び出しでバッチ統計を使い mean~0, std~1 に正規化される。"""
+        normalizer = RunningReturnNormalizer()
+        returns_t = torch.tensor([10.0, 20.0, 30.0])
+
+        result = normalizer.normalize(returns_t)
+
+        assert abs(result.mean().item()) < 1e-5
+        assert abs(result.std().item() - 1.0) < 0.2  # 3要素なので厳密に1にはならない
+        assert normalizer._initialized is True
+
+    def test_running_stats_update(self):
+        """2回目の呼び出しで running_mean/var が momentum で加重平均更新される。"""
+        normalizer = RunningReturnNormalizer(momentum=0.99)
+
+        first_returns = torch.tensor([10.0, 20.0, 30.0])
+        normalizer.normalize(first_returns)
+        first_mean = first_returns.mean().item()
+        first_var = first_returns.var().item()
+
+        second_returns = torch.tensor([100.0, 200.0, 300.0])
+        normalizer.normalize(second_returns)
+        second_mean = second_returns.mean().item()
+        second_var = second_returns.var().item()
+
+        expected_mean = 0.99 * first_mean + 0.01 * second_mean
+        expected_var = 0.99 * first_var + 0.01 * second_var
+
+        assert abs(normalizer.running_mean - expected_mean) < 1e-5
+        assert abs(normalizer.running_var - expected_var) < 1e-5
+
+    def test_constant_returns_no_nan(self):
+        """分散 0 の入力でも nan/inf が発生しない。"""
+        normalizer = RunningReturnNormalizer()
+        returns_t = torch.tensor([5.0, 5.0, 5.0])
+
+        result = normalizer.normalize(returns_t)
+
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+
+    def test_single_step_episode(self):
+        """要素数 1 のテンソルでもエラーなく正規化される。"""
+        normalizer = RunningReturnNormalizer()
+        returns_t = torch.tensor([3.0])
+
+        result = normalizer.normalize(returns_t)
+
+        assert not torch.isnan(result).any()
+        assert not torch.isinf(result).any()
+        assert result.shape == returns_t.shape
+
+    def test_reset(self):
+        """reset() で内部状態が初期値に戻り、次の normalize が初回と同じ挙動になる。"""
+        normalizer = RunningReturnNormalizer()
+
+        # 数回 normalize を呼ぶ
+        normalizer.normalize(torch.tensor([1.0, 2.0, 3.0]))
+        normalizer.normalize(torch.tensor([10.0, 20.0, 30.0]))
+        normalizer.normalize(torch.tensor([100.0, 200.0, 300.0]))
+
+        normalizer.reset()
+
+        assert normalizer._initialized is False
+        assert normalizer.running_mean == 0.0
+        assert normalizer.running_var == 1.0
+
+        # reset 後の normalize は初回と同じ挙動（バッチ統計で初期化）
+        returns_t = torch.tensor([10.0, 20.0, 30.0])
+        result = normalizer.normalize(returns_t)
+
+        assert normalizer._initialized is True
+        assert abs(normalizer.running_mean - returns_t.mean().item()) < 1e-5
+        assert abs(result.mean().item()) < 1e-5
+
+    def test_normalize_returns_flag_disabled(self):
+        """normalize を呼ばなければ _initialized は False のまま。"""
+        normalizer = RunningReturnNormalizer()
+
+        assert normalizer._initialized is False
+        assert normalizer.running_mean == 0.0
+        assert normalizer.running_var == 1.0
+
+    def test_output_shape_preserved(self):
+        """入力と出力の shape が一致する (T=1, 5, 50)。"""
+        normalizer = RunningReturnNormalizer()
+
+        for t in [1, 5, 50]:
+            normalizer.reset()
+            returns_t = torch.randn(t)
+            result = normalizer.normalize(returns_t)
+            assert result.shape == returns_t.shape, f"T={t} で shape 不一致"
+
+    def test_momentum_effect(self):
+        """momentum が小さいほど running_mean の更新が速い。"""
+        normalizer_slow = RunningReturnNormalizer(momentum=0.99)
+        normalizer_fast = RunningReturnNormalizer(momentum=0.5)
+
+        batches = [
+            torch.tensor([1.0, 2.0, 3.0]),
+            torch.tensor([100.0, 200.0, 300.0]),
+            torch.tensor([1000.0, 2000.0, 3000.0]),
+        ]
+
+        for batch in batches:
+            normalizer_slow.normalize(batch)
+            normalizer_fast.normalize(batch)
+
+        last_batch_mean = batches[-1].mean().item()
+
+        # momentum=0.5 の方が直近バッチの平均に近い（更新が速い）
+        diff_slow = abs(normalizer_slow.running_mean - last_batch_mean)
+        diff_fast = abs(normalizer_fast.running_mean - last_batch_mean)
+
+        assert diff_fast < diff_slow, (
+            f"momentum=0.5 の方が直近バッチに近いはず: "
+            f"diff_fast={diff_fast}, diff_slow={diff_slow}"
+        )


### PR DESCRIPTION
## Summary

- Critic Loss が `reward_scale` に依存して爆発する問題（#21 T8: CriticL max=226）を解決
- エピソード間で return の mean/var を指数移動平均で追跡し、Critic の学習ターゲットを正規化
- `normalize_returns: false`（デフォルト）で既存実験に影響なし

## 変更内容

### `src/gnn_ils/training/return_normalizer.py`（新規）
- `RunningReturnNormalizer`: 初回はバッチ統計で初期化、以降は EMA で mean/var を更新

### `src/gnn_ils/training/ils_a2c_strategy.py`
- `__init__`: `normalize_returns` フラグと `RunningReturnNormalizer` を追加
- `_ppo_update` / `_compute_a2c_loss`: `returns_t` 計算後に正規化を挿入

### Config パラメータ

| パラメータ | デフォルト | 説明 |
|---|---|---|
| `normalize_returns` | `false` | Return 正規化を有効にするか |
| `return_norm_momentum` | `0.99` | Running statistics の momentum |

### `tests/test_return_normalizer.py`（新規）
- 8テスト: 初回正規化、EMA更新、定数入力、単一ステップ、reset、shape保持、momentum効果

## Test plan

- [x] `pytest tests/test_return_normalizer.py -v` — 全8テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)