### PR TITLE
feat: GNN-ILS batch runner & データ生成 resume 機能

### DIFF
--- a/scripts/common/generate_data.py
+++ b/scripts/common/generate_data.py
@@ -27,9 +27,15 @@ def main():
                        help='生成するデータモード (default: train val test)')
     parser.add_argument('--force', action='store_true',
                        help='確認なしで既存データを削除して再生成')
+    parser.add_argument('--resume', action='store_true',
+                       help='既存データを保持し、途中から再開')
     parser.add_argument('--clean-only', action='store_true',
                        help='データを削除するのみ（再生成しない）')
     args = parser.parse_args()
+
+    if args.force and args.resume:
+        print("Error: --force と --resume は同時に指定できません。")
+        sys.exit(1)
     
     print("\n" + "="*60)
     print("DATASET GENERATION")
@@ -58,7 +64,7 @@ def main():
         if data_dir.exists():
             existing_dirs.append(data_dir)
 
-    if existing_dirs:
+    if existing_dirs and not args.resume:
         print(f"\n既存のデータディレクトリが見つかりました:")
         for dir_path in existing_dirs:
             print(f"  - {dir_path}")
@@ -69,12 +75,14 @@ def main():
                 print("データ生成をキャンセルしました。")
                 sys.exit(0)
 
-    # 既存データの削除
-    for mode in args.modes:
-        data_dir = get_mode_dir(mode, config)
-        if data_dir.exists():
-            shutil.rmtree(data_dir)
-            print(f"削除: {data_dir}")
+        # 既存データの削除
+        for mode in args.modes:
+            data_dir = get_mode_dir(mode, config)
+            if data_dir.exists():
+                shutil.rmtree(data_dir)
+                print(f"削除: {data_dir}")
+    elif args.resume and existing_dirs:
+        print(f"\n--resume: 既存データを保持し、途中から再開します。")
     
     if args.clean_only:
         print("\nデータ削除が完了しました。")

--- a/scripts/gnn_ils/batch_run.py
+++ b/scripts/gnn_ils/batch_run.py
@@ -45,7 +45,7 @@ def run_single_case(config_path: str, results_dir: Path, args) -> dict:
 
     # --- データ生成 ---
     if not args.skip_data_gen:
-        if not dataset_exists(config):
+        if not dataset_exists(config, check_count=True):
             print(f"\n  Generating data for {expt_name}...")
             quick_generate(config_path)
         else:
@@ -188,6 +188,7 @@ def main():
         'cases': [],
     }
 
+    interrupted = False
     for i, config_path in enumerate(args.configs):
         print(f"\n{'='*70}")
         print(f"[{i + 1}/{len(args.configs)}] {config_path}")
@@ -196,6 +197,13 @@ def main():
         try:
             result = run_single_case(config_path, results_dir, args)
             summary['cases'].append(result)
+        except KeyboardInterrupt:
+            print(f"\n  Interrupted by user. Saving partial results...")
+            summary['cases'].append({
+                'config_path': config_path,
+                'status': 'interrupted',
+            })
+            interrupted = True
         except Exception as e:
             print(f"\n  ERROR: {e}")
             traceback.print_exc()
@@ -207,6 +215,9 @@ def main():
 
         # 中間保存
         save_summary(summary, results_dir)
+
+        if interrupted:
+            break
 
     # 最終サマリー表示
     print(f"\n{'='*70}")

--- a/src/common/config/paths.py
+++ b/src/common/config/paths.py
@@ -22,9 +22,13 @@
 
 from __future__ import annotations
 
+import csv
 import os
 from pathlib import Path
 from typing import Any, Optional
+
+# データファイルをグループ化するバケットサイズ (0/, 10/, 20/, ...)
+BUCKET_SIZE = 10
 
 ENV_DATA_ROOT = "GCN_UELB_DATA_ROOT"
 ENV_MODEL_ROOT = "GCN_UELB_MODEL_ROOT"
@@ -101,12 +105,12 @@ def get_exact_solution_file(mode: str, config: Any) -> Path:
 
 def get_graph_file(mode: str, idx: int, config: Any) -> Path:
     """個別グラフファイルのパスを返す (10件ごとに番号付けされたサブディレクトリ)."""
-    bucket = idx - (idx % 10)
+    bucket = idx - (idx % BUCKET_SIZE)
     return get_mode_dir(mode, config) / "graph_file" / str(bucket) / f"graph_{idx}.gml"
 
 
 def get_commodity_file(mode: str, idx: int, config: Any) -> Path:
-    bucket = idx - (idx % 10)
+    bucket = idx - (idx % BUCKET_SIZE)
     return (
         get_mode_dir(mode, config)
         / "commodity_file"
@@ -116,7 +120,7 @@ def get_commodity_file(mode: str, idx: int, config: Any) -> Path:
 
 
 def get_node_flow_file(mode: str, idx: int, config: Any) -> Path:
-    bucket = idx - (idx % 10)
+    bucket = idx - (idx % BUCKET_SIZE)
     return (
         get_mode_dir(mode, config)
         / "node_flow_file"
@@ -125,11 +129,18 @@ def get_node_flow_file(mode: str, idx: int, config: Any) -> Path:
     )
 
 
-def dataset_exists(config: Any, modes: tuple = ("train", "val", "test")) -> bool:
+def dataset_exists(
+    config: Any,
+    modes: tuple = ("train", "val", "test"),
+    check_count: bool = False,
+) -> bool:
     """指定 config のデータセットが存在するかを確認する.
 
     各モードディレクトリと必要なサブディレクトリ (commodity_file,
     graph_file, node_flow_file) の存在をチェック。
+
+    ``check_count=True`` の場合、各モードの exact_solution.csv の行数が
+    ``num_{mode}_data`` 以上かも追加で確認する。
     """
     required_subdirs = ("commodity_file", "graph_file", "node_flow_file")
     for mode in modes:
@@ -145,5 +156,19 @@ def dataset_exists(config: Any, modes: tuple = ("train", "val", "test")) -> bool
                 d for d in sub_dir.iterdir() if d.is_dir() and d.name.isdigit()
             ]
             if not numeric_subs:
+                return False
+        if check_count:
+            expected = _config_get(config, f"num_{mode}_data")
+            if expected is None:
+                continue
+            exact_csv = mode_dir / "exact_solution.csv"
+            if not exact_csv.exists():
+                return False
+            try:
+                with open(exact_csv, 'r') as f:
+                    row_count = sum(1 for _ in csv.reader(f))
+                if row_count < int(expected):
+                    return False
+            except Exception:
                 return False
     return True

--- a/src/common/data_management/create_data_files.py
+++ b/src/common/data_management/create_data_files.py
@@ -3,8 +3,74 @@ import csv
 import networkx as nx
 from .data_maker import DataMaker
 from .exact_solution import SolveExactSolution
-from src.common.config.paths import get_mode_dir
+from src.common.config.paths import get_mode_dir, get_graph_file, get_commodity_file, get_node_flow_file, BUCKET_SIZE
 import torch
+
+
+def _count_completed_data(mode_dir, num_data):
+    """完了済みデータの連続インデックス数を返す。
+
+    exact_solution.csv の行数と、各インデックスの 3 ファイル
+    (graph, commodity, node_flow) の存在を確認し、
+    連続して揃っている最大インデックス+1 を返す。
+    """
+    exact_file = mode_dir / "exact_solution.csv"
+    if not exact_file.exists():
+        return 0
+
+    # exact_solution.csv の行数を取得
+    try:
+        with open(exact_file, 'r') as f:
+            csv_rows = list(csv.reader(f))
+        num_csv_rows = len(csv_rows)
+    except Exception:
+        return 0
+
+    if num_csv_rows == 0:
+        return 0
+
+    # 各インデックスの 3 ファイルが揃っているか確認
+    completed = 0
+    for i in range(min(num_csv_rows, num_data)):
+        bucket = i - (i % BUCKET_SIZE)
+        graph_path = mode_dir / "graph_file" / str(bucket) / f"graph_{i}.gml"
+        commodity_path = mode_dir / "commodity_file" / str(bucket) / f"commodity_data_{i}.csv"
+        node_flow_path = mode_dir / "node_flow_file" / str(bucket) / f"node_flow_{i}.csv"
+        if graph_path.exists() and commodity_path.exists() and node_flow_path.exists():
+            completed = i + 1
+        else:
+            break
+
+    return completed
+
+
+def _cleanup_incomplete(mode_dir, completed, num_data):
+    """completed 以降の不完全データを削除し、exact_solution.csv を切り詰める。"""
+    exact_file = mode_dir / "exact_solution.csv"
+
+    # exact_solution.csv を completed 行に切り詰め
+    if exact_file.exists():
+        try:
+            with open(exact_file, 'r') as f:
+                rows = list(csv.reader(f))
+            with open(exact_file, 'w', newline='') as f:
+                writer = csv.writer(f)
+                writer.writerows(rows[:completed])
+        except Exception:
+            pass
+
+    # completed 以降の個別ファイルを削除
+    for i in range(completed, num_data):
+        bucket = i - (i % BUCKET_SIZE)
+        for subdir, prefix, suffix in [
+            ("graph_file", "graph_", ".gml"),
+            ("commodity_file", "commodity_data_", ".csv"),
+            ("node_flow_file", "node_flow_", ".csv"),
+        ]:
+            path = mode_dir / subdir / str(bucket) / f"{prefix}{i}{suffix}"
+            if path.exists():
+                path.unlink()
+
 
 def create_data_files(config, data_mode="test"):
     """
@@ -28,16 +94,27 @@ def create_data_files(config, data_mode="test"):
     incorrect_value_count = 0
     non_optimal_count = 0
 
-    if os.path.exists(exact_file_name):
-        os.remove(exact_file_name)
+    # 再開ロジック: 完了済みデータ数を確認
+    start_index = _count_completed_data(mode_dir, num_data)
 
-    for i in range(num_data):
+    if start_index >= num_data:
+        print(f"All {num_data} {data_mode} data already completed. Skipping.")
+        return
+
+    if start_index > 0:
+        print(f"Resuming {data_mode} data generation from index {start_index}/{num_data}")
+        _cleanup_incomplete(mode_dir, start_index, num_data)
+    else:
+        if os.path.exists(exact_file_name):
+            os.remove(exact_file_name)
+
+    for i in range(start_index, num_data):
         data = i
-        if data % 10 == 0:
+        if data % BUCKET_SIZE == 0:
             print(f"{data} data was created.")
 
         # ディレクトリ番号の定義
-        file_number = data - (data % 10)
+        file_number = data - (data % BUCKET_SIZE)
 
         # ディレクトリ作成
         directories = ["graph_file", "commodity_file", "node_flow_file"]

--- a/src/common/data_management/dataset_reader.py
+++ b/src/common/data_management/dataset_reader.py
@@ -4,7 +4,7 @@ import networkx as nx
 import csv
 import torch
 
-from src.common.config.paths import get_mode_dir
+from src.common.config.paths import get_mode_dir, BUCKET_SIZE
 
 class DotDict(dict):
     """Wrapper around in-built dict class to access members through the dot operation.
@@ -78,7 +78,7 @@ class DatasetReader(object):
         batch_load_factor = []
 
         for i in batch_indices:
-            bucket = i - (i % 10)
+            bucket = i - (i % BUCKET_SIZE)
             # define file path
             graph_file = str(self.data_dir / 'graph_file' / str(bucket) / f'graph_{i}.gml')
             commodity_file = str(self.data_dir / 'commodity_file' / str(bucket) / f'commodity_data_{i}.csv')


### PR DESCRIPTION
## Summary
- GNN-ILS の batch runner を追加（複数 config を一括実行）
- データ生成に `--resume` オプションを追加（途中から再開可能）
- `dataset_exists` にデータ件数チェック (`check_count`) を追加
- KeyboardInterrupt 時に部分結果を保存して安全に終了
- バケットサイズ (`% 10`) を `BUCKET_SIZE` 定数に統一
- `dataset_exists` 内の `import csv` をファイル先頭に移動

## Test plan
- [ ] `python scripts/common/generate_data.py --config <config> --resume` で途中再開が動作すること
- [ ] `python scripts/gnn_ils/batch_run.py` で複数 config の一括実行が動作すること
- [ ] Ctrl+C で中断時に partial results が保存されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)