### PR TITLE
feat: RL-KSP に greedy_index0 ベースラインモードを追加

### DIFF
--- a/scripts/rl_ksp/test_rl_ksp.py
+++ b/scripts/rl_ksp/test_rl_ksp.py
@@ -27,6 +27,9 @@ def main():
                        help='Path to trained model file')
     parser.add_argument('--episodes', type=int, default=None,
                        help='Number of test episodes (default: from config)')
+    parser.add_argument('--action-mode', type=str, default=None,
+                       choices=['dqn', 'greedy_index0'],
+                       help='Action selection mode (default: dqn)')
     args = parser.parse_args()
 
     # Load configuration
@@ -52,6 +55,8 @@ def main():
     # Update config to load the specified model
     config['load_saved_model'] = True
     config['saved_model_path'] = args.model
+    if args.action_mode:
+        config['action_mode'] = args.action_mode
 
     # Initialize RL trainer
     print("\nInitializing RL trainer...")

--- a/scripts/rl_ksp/train_rl_ksp.py
+++ b/scripts/rl_ksp/train_rl_ksp.py
@@ -22,6 +22,9 @@ def main():
     parser = argparse.ArgumentParser(description='RL-KSP Training and Testing')
     parser.add_argument('--config', type=str, default='configs/rl_ksp/rl_config.json',
                        help='設定ファイルのパス (default: configs/rl_ksp/rl_config.json)')
+    parser.add_argument('--action-mode', type=str, default=None,
+                       choices=['dqn', 'greedy_index0'],
+                       help='テスト時の行動選択モード (default: dqn)')
     args = parser.parse_args()
 
     print("\n" + "="*60)
@@ -38,14 +41,22 @@ def main():
         print(f"python scripts/common/generate_data.py --config {args.config}")
         sys.exit(1)
 
-    # RL トレーナーの初期化
-    rl_trainer = RLTrainer(dict(config))
+    # action-mode の上書き（テスト時に適用）
+    config_dict = dict(config)
+    if args.action_mode:
+        config_dict['action_mode'] = args.action_mode
 
-    # 学習の実行
-    print("\n" + "="*60)
-    print("TRAINING PHASE")
-    print("="*60)
-    rl_trainer.train()
+    # RL トレーナーの初期化
+    rl_trainer = RLTrainer(config_dict)
+
+    # 学習の実行（greedy_index0 の場合はNNを使わないのでスキップ）
+    if config_dict.get('action_mode') == 'greedy_index0':
+        print("\n[action_mode=greedy_index0] Training skipped (no NN used)")
+    else:
+        print("\n" + "="*60)
+        print("TRAINING PHASE")
+        print("="*60)
+        rl_trainer.train()
 
     # テストの実行
     print("\n" + "="*60)

--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -256,25 +256,40 @@ class RLTrainer:
         
     def choose_action(self, state: np.ndarray) -> int:
         """
-        ニューラルネットワークの予測値に基づく行動選択
-        
+        行動選択（action_mode設定で切り替え可能）
+
+        action_mode:
+            "dqn" (default): DQNによるQ値ベースの行動選択
+            "greedy_index0": 常にindex 0を選択（候補リストは降順ソート済みなので最大改善量）
+
         Args:
             state: 現在の状態
-            
+
         Returns:
             選択された行動
         """
+        action_mode = self.config.get('action_mode', 'dqn')
+
+        if action_mode == 'greedy_index0':
+            # 降順ソート済みなのでindex 0が最大改善量
+            # ただし-100.0（無効候補）の場合はスキップ
+            for i, val in enumerate(state):
+                if val != -100.0:
+                    return i
+            return 0
+
+        # DQNによる行動選択
         with torch.no_grad():
             state_tensor = torch.FloatTensor(state).unsqueeze(0).to(self.device)
             q_values = self.model(state_tensor)
-            
+
             # 観測変数が-100.0の場合は、その行動を選択しない
             filtered_q_values = torch.where(
                 torch.FloatTensor(state).to(self.device) == -100.0,
                 torch.FloatTensor([-float('inf')]).to(self.device),
                 q_values.squeeze(0)
             )
-            
+
             action = torch.argmax(filtered_q_values).item()
             return action
     


### PR DESCRIPTION
## Summary
- RL-KSPのDQNが実質argmaxと同等かを検証するため、常にindex 0（最大改善量）を選択する greedy baseline モードを追加
- `--action-mode greedy_index0` でコマンドラインから指定可能
- `greedy_index0` モード時はNNを使わないため学習フェーズをスキップ

## 使い方
```bash
# greedy baseline でテスト
python scripts/rl_ksp/train_rl_ksp.py --config configs/rl_ksp/rl_config.json --action-mode greedy_index0

# DQN（従来通り）
python scripts/rl_ksp/train_rl_ksp.py --config configs/rl_ksp/rl_config.json
```

## 変更ファイル
- `src/rl_ksp/train/rl_trainer.py` — `choose_action` に `greedy_index0` モード追加
- `scripts/rl_ksp/train_rl_ksp.py` — `--action-mode` 引数追加、greedy時の学習スキップ
- `scripts/rl_ksp/test_rl_ksp.py` — `--action-mode` 引数追加

## Test plan
- [ ] `--action-mode greedy_index0` でテストが正常に動作すること
- [ ] `--action-mode dqn`（デフォルト）で従来通り動作すること
- [ ] DQN vs greedy_index0 の性能差を比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)