### PR TITLE
feat: KSP-LP (PILP) ソルバーの実装

### DIFF
--- a/scripts/common/compute_ksp_lp.py
+++ b/scripts/common/compute_ksp_lp.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""既存データセットに対して KSP-LP を後付け計算するスタンドアロンスクリプト."""
+
+import sys
+import os
+import csv
+import argparse
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+import networkx as nx
+from src.common.data_management.ksp_lp_solution import SolveKspLpSolution
+from src.common.config.paths import BUCKET_SIZE
+
+
+def _count_existing_rows(filepath: Path) -> int:
+    """CSV の行数を返す。ファイルが無ければ 0。"""
+    if not filepath.exists():
+        return 0
+    try:
+        with open(filepath, 'r') as f:
+            return sum(1 for _ in csv.reader(f))
+    except Exception:
+        return 0
+
+
+def _get_graph_path(mode_dir: Path, idx: int) -> Path:
+    bucket = idx - (idx % BUCKET_SIZE)
+    return mode_dir / "graph_file" / str(bucket) / f"graph_{idx}.gml"
+
+
+def _get_commodity_path(mode_dir: Path, idx: int) -> Path:
+    bucket = idx - (idx % BUCKET_SIZE)
+    return mode_dir / "commodity_file" / str(bucket) / f"commodity_data_{idx}.csv"
+
+
+def _load_commodity_list(filepath: Path) -> list:
+    with open(filepath, newline='') as f:
+        reader = csv.reader(f)
+        return [[int(item) for item in row] for row in reader]
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Compute KSP-LP for existing datasets')
+    parser.add_argument('--dataset_dir', type=str, required=True,
+                        help='データセットディレクトリ (例: ~/Projects/ml-data/.../gnn_ils_nsfnet_c10)')
+    parser.add_argument('--modes', type=str, nargs='+', default=['test'],
+                        choices=['train', 'val', 'test'],
+                        help='計算するデータモード (default: test)')
+    parser.add_argument('--K', type=int, default=10,
+                        help='KSP 候補経路数 (default: 10)')
+    parser.add_argument('--solver_time_limit', type=float, default=None,
+                        help='ソルバー制限時間（秒）。未指定で制限なし')
+    parser.add_argument('--resume', action='store_true',
+                        help='既存の ksp_lp_solution.csv の続きから再開')
+    args = parser.parse_args()
+
+    dataset_dir = Path(args.dataset_dir).expanduser()
+    if not dataset_dir.exists():
+        print(f"Error: Dataset directory not found: {dataset_dir}")
+        sys.exit(1)
+
+    print("\n" + "=" * 60)
+    print("KSP-LP COMPUTATION")
+    print("=" * 60)
+    print(f"Dataset: {dataset_dir}")
+    print(f"Modes: {', '.join(args.modes)}")
+    print(f"K: {args.K}")
+    print(f"Solver time limit: {args.solver_time_limit or 'None (unlimited)'}")
+
+    for mode in args.modes:
+        mode_dir = dataset_dir / f"{mode}_data"
+        if not mode_dir.exists():
+            print(f"\nSkipping {mode}: {mode_dir} not found")
+            continue
+
+        # サンプル数を exact_solution.csv から検出
+        exact_file = mode_dir / "exact_solution.csv"
+        num_data = _count_existing_rows(exact_file)
+        if num_data == 0:
+            print(f"\nSkipping {mode}: exact_solution.csv is empty or missing")
+            continue
+
+        ksp_lp_file = mode_dir / "ksp_lp_solution.csv"
+
+        # レジューム対応
+        start_index = 0
+        if args.resume:
+            start_index = _count_existing_rows(ksp_lp_file)
+            if start_index >= num_data:
+                print(f"\n{mode}: All {num_data} samples already computed. Skipping.")
+                continue
+            if start_index > 0:
+                print(f"\n{mode}: Resuming from index {start_index}/{num_data}")
+        else:
+            # 既存ファイルがあれば削除
+            if ksp_lp_file.exists():
+                ksp_lp_file.unlink()
+
+        print(f"\n{mode.upper()}: Computing KSP-LP for {num_data - start_index} samples...")
+
+        for i in range(start_index, num_data):
+            graph_path = _get_graph_path(mode_dir, i)
+            commodity_path = _get_commodity_path(mode_dir, i)
+
+            if not graph_path.exists() or not commodity_path.exists():
+                print(f"  Warning: Missing files for sample {i}, writing fallback row")
+                with open(ksp_lp_file, 'a', newline='') as f:
+                    csv.writer(f).writerow([1.0, 0.0, 0.0, 0])
+                continue
+
+            G = nx.read_gml(str(graph_path), destringizer=int)
+            commodity_list = _load_commodity_list(commodity_path)
+
+            try:
+                solver = SolveKspLpSolution(
+                    G, commodity_list, K=args.K,
+                    solver_time_limit=args.solver_time_limit
+                )
+                result = solver.solve()
+
+                with open(ksp_lp_file, 'a', newline='') as f:
+                    csv.writer(f).writerow([
+                        result['objective_value'],
+                        result['elapsed_time'],
+                        result['ksp_elapsed_time'],
+                        1 if result['is_optimal'] else 0,
+                    ])
+
+                print(f"  Sample {i + 1}/{num_data}, "
+                      f"KSP-LP MLU: {result['objective_value']:.4f}, "
+                      f"Time: {result['elapsed_time']:.3f}s")
+
+            except Exception as e:
+                print(f"  Error for sample {i}: {e}")
+                with open(ksp_lp_file, 'a', newline='') as f:
+                    csv.writer(f).writerow([1.0, 0.0, 0.0, 0])
+
+        final_count = _count_existing_rows(ksp_lp_file)
+        print(f"  {mode} completed: {final_count} rows in ksp_lp_solution.csv")
+
+    print("\n" + "=" * 60)
+    print("KSP-LP computation finished.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/common/data_management/create_data_files.py
+++ b/src/common/data_management/create_data_files.py
@@ -3,6 +3,7 @@ import csv
 import networkx as nx
 from .data_maker import DataMaker
 from .exact_solution import SolveExactSolution
+from .ksp_lp_solution import SolveKspLpSolution
 from src.common.config.paths import get_mode_dir, get_graph_file, get_commodity_file, get_node_flow_file, BUCKET_SIZE
 import torch
 
@@ -42,6 +43,18 @@ def _count_completed_data(mode_dir, num_data):
             break
 
     return completed
+
+
+def _truncate_csv(filepath, num_rows):
+    """CSV ファイルを先頭 num_rows 行に切り詰める。"""
+    try:
+        with open(filepath, 'r') as f:
+            rows = list(csv.reader(f))
+        with open(filepath, 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerows(rows[:num_rows])
+    except Exception:
+        pass
 
 
 def _cleanup_incomplete(mode_dir, completed, num_data):
@@ -86,10 +99,17 @@ def create_data_files(config, data_mode="test"):
     require_optimal = getattr(config, 'require_optimal', True)
     Maker = DataMaker(config)
 
+    # KSP-LP 設定の読み込み
+    ksp_lp_config = getattr(config, 'ksp_lp', None) or {}
+    ksp_lp_enabled = ksp_lp_config.get('enabled', False) if isinstance(ksp_lp_config, dict) else False
+    ksp_lp_K = ksp_lp_config.get('K', 10) if isinstance(ksp_lp_config, dict) else 10
+    ksp_lp_time_limit = ksp_lp_config.get('solver_time_limit', None) if isinstance(ksp_lp_config, dict) else None
+
     mode_dir = get_mode_dir(data_mode, config)
     mode_dir.mkdir(parents=True, exist_ok=True)
 
     exact_file_name = str(mode_dir / "exact_solution.csv")
+    ksp_lp_file_name = str(mode_dir / "ksp_lp_solution.csv")
     infinit_loop_count = 0
     incorrect_value_count = 0
     non_optimal_count = 0
@@ -104,9 +124,14 @@ def create_data_files(config, data_mode="test"):
     if start_index > 0:
         print(f"Resuming {data_mode} data generation from index {start_index}/{num_data}")
         _cleanup_incomplete(mode_dir, start_index, num_data)
+        # KSP-LP の CSV も切り詰め
+        if ksp_lp_enabled and os.path.exists(ksp_lp_file_name):
+            _truncate_csv(ksp_lp_file_name, start_index)
     else:
         if os.path.exists(exact_file_name):
             os.remove(exact_file_name)
+        if ksp_lp_enabled and os.path.exists(ksp_lp_file_name):
+            os.remove(ksp_lp_file_name)
 
     for i in range(start_index, num_data):
         data = i
@@ -170,28 +195,50 @@ def create_data_files(config, data_mode="test"):
         # 厳密解保存
         with open(exact_file_name, 'a', newline='') as f:
             out = csv.writer(f)
-            out.writerow([objective_value, elapsed_time]) 
+            out.writerow([objective_value, elapsed_time])
 
         # 厳密解ノードフロー保存
         with open(node_flow_file_name, 'w', newline='') as file:
             writer = csv.writer(file)
             for row in node_flow_matrix:
                 writer.writerow(row)
-        
+
+        # KSP-LP 計算
+        if ksp_lp_enabled:
+            try:
+                ksp_lp_solver = SolveKspLpSolution(
+                    G, commodity_list, K=ksp_lp_K,
+                    solver_time_limit=ksp_lp_time_limit
+                )
+                ksp_lp_result = ksp_lp_solver.solve()
+                with open(ksp_lp_file_name, 'a', newline='') as f:
+                    out = csv.writer(f)
+                    out.writerow([
+                        ksp_lp_result['objective_value'],
+                        ksp_lp_result['elapsed_time'],
+                        ksp_lp_result['ksp_elapsed_time'],
+                        1 if ksp_lp_result['is_optimal'] else 0,
+                    ])
+            except Exception as e:
+                print(f"Warning: KSP-LP failed for data {data}: {e}")
+                with open(ksp_lp_file_name, 'a', newline='') as f:
+                    out = csv.writer(f)
+                    out.writerow([1.0, 0.0, 0.0, 0])
+
         """必要ないので一旦スキップ
         # 厳密解エッジフロー保存
         with open(edge_flow_file_name, 'w', newline='') as file:
             writer = csv.writer(file)
             for row in edge_flow_matrix:
                 writer.writerow(row)
-        
+
         # エッジ保存
         with open(edge_file_name, 'w', newline='') as file:
             writer = csv.writer(file)
             for item in edge_list:
                 writer.writerow([item[0], item[1][0], item[1][1]])
         """
-    
+
     print(f"Data generation completed: {num_data} data created.")
     print(f"Infinit loops: {infinit_loop_count}, Incorrect values: {incorrect_value_count}, Non-optimal (discarded): {non_optimal_count} (time_limit={solver_time_limit}s)")
 

--- a/src/common/data_management/ksp_lp_solution.py
+++ b/src/common/data_management/ksp_lp_solution.py
@@ -1,0 +1,131 @@
+"""KSP-LP (PILP: Path-based Integer Linear Programming) ソルバー.
+
+KSP 候補経路内での最適 MLU を求める。
+全パス ILP と異なり変数が K×C と小規模なため、大規模グラフでも高速に解ける。
+"""
+
+import time
+import pulp
+import networkx as nx
+from typing import List
+
+from src.common.graph.k_shortest_path import KShortestPathFinder
+
+
+class SolveKspLpSolution:
+    """KSP候補経路内でのPILP（Path-based ILP）を解く"""
+
+    def __init__(self, graph: nx.Graph, commodity_list: List[List[int]],
+                 K: int = 10, solver_time_limit=None):
+        """
+        Args:
+            graph: NetworkXグラフ（edge属性に'capacity'）
+            commodity_list: [[source, sink, demand], ...]
+            K: 候補経路数（デフォルト10）
+            solver_time_limit: ソルバー制限時間（秒）。None の場合は制限なし
+        """
+        self.graph = graph
+        self.commodity_list = commodity_list
+        self.K = K
+        self.solver_time_limit = solver_time_limit
+
+    def solve(self) -> dict:
+        """KSP-LP を解く.
+
+        Returns:
+            dict: {
+                'objective_value': float,   # KSP-LP 最適 MLU
+                'elapsed_time': float,      # PILP ソルバー実行時間（秒）
+                'is_optimal': bool,         # 最適性が証明されたか
+                'selected_paths': list,     # 各品種が選択したパスのインデックス
+                'ksp_elapsed_time': float,  # KSP 候補生成にかかった時間
+            }
+        """
+        # 1. KSP 候補経路を生成
+        ksp_finder = KShortestPathFinder()
+        ksp_start = time.time()
+        all_ksp = ksp_finder.search_k_shortest_paths(
+            self.graph, self.commodity_list, self.K
+        )
+        ksp_elapsed = time.time() - ksp_start
+
+        # 2. PILP を定式化
+        problem = pulp.LpProblem('KSP_LP', pulp.LpMinimize)
+
+        # MLU 変数
+        alpha = pulp.LpVariable('alpha', lowBound=0, upBound=1, cat='Continuous')
+        problem += (alpha, "Objective")
+
+        # x_{k,p} 変数: 品種 k が候補パス p を使うか (0-1)
+        num_commodities = len(self.commodity_list)
+        x = {}
+        for k in range(num_commodities):
+            num_paths = len(all_ksp[k])
+            for p in range(num_paths):
+                x[k, p] = pulp.LpVariable(f'x_{k}_{p}', cat=pulp.LpBinary)
+
+        # 制約1: 各品種は候補から1本選択
+        for k in range(num_commodities):
+            num_paths = len(all_ksp[k])
+            problem += (
+                pulp.lpSum(x[k, p] for p in range(num_paths)) == 1,
+                f"select_one_{k}"
+            )
+
+        # エッジ → 容量のマッピングを構築
+        capacity = nx.get_edge_attributes(self.graph, 'capacity')
+
+        # 制約2: リンク容量制約
+        # 各エッジについて、そのエッジを通るパスの需要合計 <= alpha * capacity
+        # まず各エッジを使う (k, p) の組を事前計算
+        edge_usage = {}  # edge -> [(k, p, demand), ...]
+        for k in range(num_commodities):
+            demand = self.commodity_list[k][2]
+            for p, path in enumerate(all_ksp[k]):
+                for i in range(len(path) - 1):
+                    edge = (path[i], path[i + 1])
+                    if edge not in edge_usage:
+                        edge_usage[edge] = []
+                    edge_usage[edge].append((k, p, demand))
+
+        for edge, usages in edge_usage.items():
+            cap = capacity.get(edge)
+            if cap is None:
+                continue
+            problem += (
+                pulp.lpSum(d * x[k, p] for k, p, d in usages) <= alpha * cap,
+                f"cap_{edge[0]}_{edge[1]}"
+            )
+
+        # 3. 求解
+        solver_kwargs = {'msg': False}
+        if self.solver_time_limit is not None:
+            solver_kwargs['timeLimit'] = self.solver_time_limit
+
+        solve_start = time.time()
+        status = problem.solve(pulp.PULP_CBC_CMD(**solver_kwargs))
+        solve_elapsed = time.time() - solve_start
+
+        is_optimal = pulp.LpStatus[status] == 'Optimal'
+        if self.solver_time_limit is not None:
+            is_optimal = is_optimal and (solve_elapsed < self.solver_time_limit - 1.0)
+
+        objective_value = alpha.value() if alpha.value() is not None else 1.0
+
+        # 選択されたパスのインデックスを取得
+        selected_paths = []
+        for k in range(num_commodities):
+            selected = 0
+            for p in range(len(all_ksp[k])):
+                if pulp.value(x[k, p]) == 1:
+                    selected = p
+                    break
+            selected_paths.append(selected)
+
+        return {
+            'objective_value': objective_value,
+            'elapsed_time': solve_elapsed,
+            'is_optimal': is_optimal,
+            'selected_paths': selected_paths,
+            'ksp_elapsed_time': ksp_elapsed,
+        }


### PR DESCRIPTION
## 概要

KSP候補経路内でのPath-based ILP（PILP）最適解を求めるソルバーを追加。
IEEE Journal論文でKSP-Iterativeの近似率を評価する際の基準（分母）として使用する。

$$\text{Approximation Ratio} = \frac{\text{KSP-Iterative の MLU}}{\text{KSP-LP の最適 MLU}}$$

## 変更内容

### 新規ファイル
- **`src/common/data_management/ksp_lp_solution.py`** — `SolveKspLpSolution` クラス
  - `KShortestPathFinder` で各品種のK本候補経路を生成
  - PuLP (CBC) でPILPを定式化・求解（変数: K×C の0-1変数）
  - 全パスILPと異なり小規模MIPなので大規模グラフでも高速に解ける

- **`scripts/common/compute_ksp_lp.py`** — 既存データセットへの後付け計算スクリプト
  - `--resume` によるレジューム対応
  - `exact_solution.csv` の行数からサンプル数を自動検出

### 変更ファイル
- **`src/common/data_management/create_data_files.py`** — データ生成パイプラインへの統合
  - config の `ksp_lp.enabled` が `true` の場合のみ動作（後方互換性維持）
  - 再開時の `ksp_lp_solution.csv` 切り詰めにも対応

## 使い方

### データ生成時に同時計算（config に追記）
```json
{
  "ksp_lp": {
    "enabled": true,
    "K": 10,
    "solver_time_limit": null
  }
}
```

### 既存データセットへの後付け計算
```bash
python scripts/common/compute_ksp_lp.py \
  --dataset_dir ~/Projects/ml-data/graph-convnet-uelb/datasets/gnn_ils_nsfnet_c10 \
  --modes test --K 10
```

## 出力フォーマット

`ksp_lp_solution.csv`（ヘッダーなし）:
| 列 | 説明 |
|---|---|
| ksp_lp_objective | KSP-LP の最適 MLU |
| ksp_lp_time | PILP ソルバー実行時間（秒） |
| ksp_time | KSP 候補生成時間（秒） |
| is_optimal | 最適性証明済みか（1/0） |

## テスト計画

- [ ] 小規模データセット（C5, random 40ノード）で `compute_ksp_lp.py` を実行し、`ksp_lp_solution.csv` が正しく生成されることを確認
- [ ] `ksp_lp.enabled: true` を config に追加してデータ生成し、厳密解と同時に KSP-LP が計算されることを確認
- [ ] `--resume` フラグで途中再開が正しく動作することを確認
- [ ] `ksp_lp` 設定なしの既存 config でデータ生成が壊れないことを確認（後方互換性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)