### PR TITLE
feat: コモディティ生成改善と KSP-ILP time_limit config対応

### DIFF
--- a/src/common/data_management/create_data_files.py
+++ b/src/common/data_management/create_data_files.py
@@ -199,7 +199,8 @@ def create_data_files(config, data_mode="test"):
     # KSP-ILP 事前計算
     K = getattr(config, 'K', None)
     if K is not None:
-        compute_ksp_ilp_solutions(config, data_mode, num_data, K, solver_time_limit)
+        ksp_ilp_time_limit = getattr(config, 'ksp_ilp_time_limit', 300)
+        compute_ksp_ilp_solutions(config, data_mode, num_data, K, ksp_ilp_time_limit)
 
 
 def compute_ksp_ilp_solutions(config, data_mode, num_data, K, time_limit=30):

--- a/src/common/graph/graph_utils.py
+++ b/src/common/graph/graph_utils.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn.functional as F
 
+import itertools
 import numpy as np
 import random
 
@@ -265,27 +266,16 @@ def get_max_k(dataset, max_iter=1000):
     # print(f"Mean: {np.mean(ks)}, StdDev: {np.std(ks)}")
     return int(np.max(ks))
 
-def generate_commodity(G, demand_l, demand_h, commodity): # 品種の定義(numpy使用)
-    determin_st = []
+def generate_commodity(G, demand_l, demand_h, commodity): # 品種の定義
+    nodes = list(G.nodes)
+    all_pairs = list(itertools.permutations(nodes, 2))
+    if commodity > len(all_pairs):
+        raise ValueError(f"commodity数 {commodity} がユニークペア数 {len(all_pairs)} を超えています")
+    selected_pairs = random.sample(all_pairs, commodity)
     commodity_list = []
-    for i in range(commodity): # commodity generate
-        commodity_dict = {}
-        s , t = tuple(random.sample(G.nodes, 2)) # source，sink定義
-        demand = random.randint(demand_l, demand_h) # demand設定
-        tentative_st = [s,t]
-        while True:
-            if tentative_st in determin_st:
-                s , t = tuple(random.sample(G.nodes, 2)) # source，sink再定義
-                tentative_st = [s,t]
-            else:
-                break
-        determin_st.append(tentative_st) # commodity決定
-        commodity_dict["id"] = i
-        commodity_dict["source"] = s
-        commodity_dict["sink"] = t
-        commodity_dict["demand"] = demand
-
-        commodity_list.append([s,t,demand])
+    for s, t in selected_pairs:
+        demand = random.randint(demand_l, demand_h)
+        commodity_list.append([s, t, demand])
     commodity_list.sort(key=lambda x: -x[2]) # demand大きいものから降順
 
     return commodity_list

--- a/src/common/solvers/ksp_ilp.py
+++ b/src/common/solvers/ksp_ilp.py
@@ -36,7 +36,7 @@ class KspIlpResult:
 class KspIlpSolver:
     """KSP 候補パス内で ILP を解いて最適パス割当を求めるソルバー."""
 
-    def __init__(self, solver_name: str = 'HiGHS', time_limit: int = 30):
+    def __init__(self, solver_name: str = 'HiGHS', time_limit: int = 300):
         self.solver_name = solver_name
         self.time_limit = time_limit
         self._solver = self._resolve_solver()


### PR DESCRIPTION
## Summary
- `generate_commodity` を while ループ再サンプリングから `itertools.permutations` + `random.sample` 方式に変更し、コモディティ数増加時のパフォーマンス問題を解消
- KSP-ILP ソルバーのデフォルト `time_limit` を 30秒→300秒に変更
- KSP-ILP の `time_limit` を config の `ksp_ilp_time_limit` キーから個別設定可能に

## Test plan
- [ ] 既存の設定でデータ生成が正常に動作することを確認
- [ ] コモディティ数を増やした場合に生成が高速に完了することを確認
- [ ] `ksp_ilp_time_limit` を config に設定して反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)