### PR TITLE
chore: nsfnet_cXXX_rho04 configs に action_mode=greedy_index0 を追加

### DIFF
--- a/configs/rl_ksp/nsfnet_c120_rho04.json
+++ b/configs/rl_ksp/nsfnet_c120_rho04.json
@@ -67,5 +67,6 @@
     "save_every_n_episodes": 1000000,
     "load_saved_model": false,
     "load_model_epoch": null,
-    "cleanup_old_models": true
+    "cleanup_old_models": true,
+    "action_mode": "greedy_index0"
 }

--- a/configs/rl_ksp/nsfnet_c150_rho04.json
+++ b/configs/rl_ksp/nsfnet_c150_rho04.json
@@ -67,5 +67,6 @@
     "save_every_n_episodes": 1000000,
     "load_saved_model": false,
     "load_model_epoch": null,
-    "cleanup_old_models": true
+    "cleanup_old_models": true,
+    "action_mode": "greedy_index0"
 }

--- a/configs/rl_ksp/nsfnet_c180_rho04.json
+++ b/configs/rl_ksp/nsfnet_c180_rho04.json
@@ -68,5 +68,6 @@
     "save_every_n_episodes": 1000000,
     "load_saved_model": false,
     "load_model_epoch": null,
-    "cleanup_old_models": true
+    "cleanup_old_models": true,
+    "action_mode": "greedy_index0"
 }

--- a/configs/rl_ksp/nsfnet_c30_rho04.json
+++ b/configs/rl_ksp/nsfnet_c30_rho04.json
@@ -68,5 +68,6 @@
     "save_every_n_episodes": 1000000,
     "load_saved_model": false,
     "load_model_epoch": null,
-    "cleanup_old_models": true
+    "cleanup_old_models": true,
+    "action_mode": "greedy_index0"
 }

--- a/configs/rl_ksp/nsfnet_c60_rho04.json
+++ b/configs/rl_ksp/nsfnet_c60_rho04.json
@@ -67,5 +67,6 @@
     "save_every_n_episodes": 1000000,
     "load_saved_model": false,
     "load_model_epoch": null,
-    "cleanup_old_models": true
+    "cleanup_old_models": true,
+    "action_mode": "greedy_index0"
 }

--- a/configs/rl_ksp/nsfnet_c90_rho04.json
+++ b/configs/rl_ksp/nsfnet_c90_rho04.json
@@ -67,5 +67,6 @@
     "save_every_n_episodes": 1000000,
     "load_saved_model": false,
     "load_model_epoch": null,
-    "cleanup_old_models": true
+    "cleanup_old_models": true,
+    "action_mode": "greedy_index0"
 }


### PR DESCRIPTION
## Summary

- `configs/rl_ksp/nsfnet_c{30,60,90,120,150,180}_rho04.json` の全6ファイルに `"action_mode": "greedy_index0"` を追加
- これにより DQN（NN）を使わず、常に最大改善量の候補パス交換を選ぶ KSP-Greedy がデフォルト動作になる
- CLI で `--action-mode` を明示しなくても greedy_index0 が適用される

## Test plan

- [ ] `python scripts/rl_ksp/train_rl_ksp.py --config configs/rl_ksp/nsfnet_c30_rho04.json` を実行し、Training skipped (no NN used) と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)