### PR TITLE
feat: RL-KSP テスト時に厳密解・KSP-ILPベースライン比較メトリクスを追加

### DIFF
--- a/src/gcn/train/metrics.py
+++ b/src/gcn/train/metrics.py
@@ -31,6 +31,11 @@ class MetricsLogger:
         self.test_comp_rate_list = []
         self.test_comp_sample_rate_list = []
 
+        # Baseline comparison metrics (test only)
+        self.test_avg_exact_load_list = []      # テスト時の平均厳密解 load factor
+        self.test_avg_ksp_ilp_load_list = []    # テスト時の平均KSP-ILPベースライン load factor
+        self.test_ksp_ilp_approx_rate_list = [] # KSP-ILPとの近似率 (exact/ksp_ilp*100)
+
         # RL-specific metrics (existing)
         self.rl_reward_list = []
         self.rl_advantage_list = []
@@ -74,7 +79,9 @@ class MetricsLogger:
             self.val_comp_sample_rate_list.append(comp_sample_rate)
 
     def log_test_metrics(self, approximation_rate: float, test_time: float = None, epoch: int = None,
-                         comp_rate: float = None, comp_sample_rate: float = None):
+                         comp_rate: float = None, comp_sample_rate: float = None,
+                         avg_exact_load: float = None, avg_ksp_ilp_load: float = None,
+                         ksp_ilp_approx_rate: float = None):
         """テストメトリクスを記録"""
         self.test_approximation_rate_list.append(approximation_rate)
         if test_time is not None:
@@ -86,6 +93,12 @@ class MetricsLogger:
             self.test_comp_rate_list.append(comp_rate)
         if comp_sample_rate is not None:
             self.test_comp_sample_rate_list.append(comp_sample_rate)
+        if avg_exact_load is not None:
+            self.test_avg_exact_load_list.append(avg_exact_load)
+        if avg_ksp_ilp_load is not None:
+            self.test_avg_ksp_ilp_load_list.append(avg_ksp_ilp_load)
+        if ksp_ilp_approx_rate is not None:
+            self.test_ksp_ilp_approx_rate_list.append(ksp_ilp_approx_rate)
 
     def log_rl_metrics(self, epoch: int, rl_metrics: dict):
         """RL特有のメトリクスを記録"""
@@ -225,6 +238,12 @@ class MetricsLogger:
                     f.write(f"  Final Test Comp Rate: {self.test_comp_rate_list[-1]:.2f}%\n")
                 if self.test_comp_sample_rate_list:
                     f.write(f"  Final Test CompSample Rate: {self.test_comp_sample_rate_list[-1]:.2f}%\n")
+                if self.test_avg_exact_load_list:
+                    f.write(f"  Avg Exact Solution Load Factor: {self.test_avg_exact_load_list[-1]:.6f}\n")
+                if self.test_avg_ksp_ilp_load_list:
+                    f.write(f"  Avg KSP-ILP Baseline Load Factor: {self.test_avg_ksp_ilp_load_list[-1]:.6f}\n")
+                if self.test_ksp_ilp_approx_rate_list:
+                    f.write(f"  KSP-ILP Approx Rate (Exact/KSP-ILP): {self.test_ksp_ilp_approx_rate_list[-1]:.2f}%\n")
             
             # 時間関連のメトリクス
             f.write("\nTIME METRICS:\n")

--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -26,6 +26,7 @@ from src.common.config.paths import (
     get_graph_file,
     get_commodity_file,
     get_exact_solution_file,
+    get_ksp_ilp_solution_file,
 )
 
 
@@ -429,8 +430,29 @@ class RLTrainer:
         for i, batch in enumerate(dataset_for_cache):
             gt_load_factor_cache[i] = float(np.mean(batch.load_factor))
 
+        # KSP-ILP ベースラインをキャッシュ（config に K が設定されていれば）
+        ksp_ilp_cache: Dict[int, float] = {}
+        K = self.config.get('K', None)
+        if K is not None:
+            ksp_ilp_file = get_ksp_ilp_solution_file('test', self.config, K)
+            if ksp_ilp_file.exists():
+                with open(ksp_ilp_file, 'r') as f:
+                    for idx, line in enumerate(f):
+                        line = line.strip()
+                        if line:
+                            parts = line.split(',')
+                            try:
+                                ksp_ilp_cache[idx] = float(parts[0])
+                            except (ValueError, IndexError):
+                                pass
+            else:
+                print(f"[Warning] KSP-ILP solution file not found: {ksp_ilp_file}")
+
         test_results = []
         episode_approx_rates: List[float] = []
+        episode_gt_loads: List[float] = []
+        episode_ksp_ilp_loads: List[float] = []
+        episode_ksp_ilp_approx_rates: List[float] = []  # 同一サンプルの gt/ksp_ilp 比
         total_test_time = 0.0
         # フェーズ別累積時間
         phase_totals = {
@@ -498,6 +520,12 @@ class RLTrainer:
                 exit(1)
 
             episode_approx_rates.append(approximation_rate)
+            episode_gt_loads.append(gt_load_factor)
+            if current_data_idx in ksp_ilp_cache:
+                ksp_ilp_lf = ksp_ilp_cache[current_data_idx]
+                episode_ksp_ilp_loads.append(ksp_ilp_lf)
+                if ksp_ilp_lf > 0:
+                    episode_ksp_ilp_approx_rates.append(gt_load_factor / ksp_ilp_lf * 100)
 
             test_results.append({
                 'episode': episode + 1,
@@ -520,7 +548,19 @@ class RLTrainer:
 
         # 全エピソードの平均 approximation rate を1回だけ記録（GCN と同じ粒度）
         mean_approx_rate = float(np.mean(episode_approx_rates)) if episode_approx_rates else 0.0
-        self.metrics_logger.log_test_metrics(mean_approx_rate, total_test_time)
+
+        # ベースライン比較メトリクスの計算
+        avg_exact_load = float(np.mean(episode_gt_loads)) if episode_gt_loads else None
+        avg_ksp_ilp_load = float(np.mean(episode_ksp_ilp_loads)) if episode_ksp_ilp_loads else None
+        # ksp_ilp_approx_rate はエピソード毎の比の平均（同一サンプルで計算）
+        ksp_ilp_approx_rate = float(np.mean(episode_ksp_ilp_approx_rates)) if episode_ksp_ilp_approx_rates else None
+
+        self.metrics_logger.log_test_metrics(
+            mean_approx_rate, total_test_time,
+            avg_exact_load=avg_exact_load,
+            avg_ksp_ilp_load=avg_ksp_ilp_load,
+            ksp_ilp_approx_rate=ksp_ilp_approx_rate,
+        )
 
         # 統計の表示（GCNと同じスタイル）
         avg_reward = np.mean([r['total_reward'] for r in test_results])
@@ -534,6 +574,12 @@ class RLTrainer:
         print(f"Average Total Reward: {avg_reward:.6f}")
         print(f"Average Max Load Factor: {avg_max_load:.6f}")
         print(f"Average Approximation Rate: {mean_approx_rate:.2f}%")
+        if avg_exact_load is not None:
+            print(f"Avg Exact Solution Load Factor: {avg_exact_load:.6f}")
+        if avg_ksp_ilp_load is not None:
+            print(f"Avg KSP-ILP Baseline Load Factor: {avg_ksp_ilp_load:.6f}")
+        if ksp_ilp_approx_rate is not None:
+            print(f"KSP-ILP Approx Rate (Exact/KSP-ILP): {ksp_ilp_approx_rate:.2f}%")
         print(f"Average Steps per Episode: {avg_steps:.2f}")
         print(f"Average Time per Episode: {avg_time:.4f}s")
         print(f"Total Test Time: {total_test_time:.2f}s")


### PR DESCRIPTION
## 概要

RL-KSP のテスト結果に、厳密解および KSP-ILP ベースラインとの比較メトリクスを追加した。

## 追加メトリクス

| メトリクス | 説明 |
|---|---|
| Avg Exact Solution Load Factor | テスト全エピソードの厳密解 load factor の平均 |
| Avg KSP-ILP Baseline Load Factor | テスト全エピソードの KSP-ILP load factor の平均 |
| KSP-ILP Approx Rate (Exact/KSP-ILP) | エピソード毎の `exact / ksp_ilp` 比の平均（同一サンプルで計算） |

## 出力先

- コンソールの `RL TEST RESULTS SUMMARY` セクション
- `logs/training_results_{timestamp}.txt` の FINAL METRICS セクション

## 動作条件

- config に `K` が設定されており、かつ `ksp_ilp_K{K}_solution.csv` が存在する場合のみ KSP-ILP 系メトリクスが出力される
- `K` 未設定時はサイレントスキップ（意図的な設定なので warning なし）
- ファイル未存在時は `[Warning]` を表示してスキップ

## 変更ファイル

- `src/gcn/train/metrics.py`: `MetricsLogger` に新フィールド追加・`log_test_metrics()` の引数追加・txt 出力に追記
- `src/rl_ksp/train/rl_trainer.py`: KSP-ILP キャッシュ構築・エピソード毎の比収集・集計ロジック追加

## 統計的正確性

`ksp_ilp_approx_rate` は `mean(exact_i) / mean(ksp_ilp_i)`（異なるサンプル集合の比）ではなく、`mean(exact_i / ksp_ilp_i)`（エピソード毎の比の平均）で計算しており、サンプル集合の不一致を回避している。