### PR TITLE
fix: ratioGap 使用時の mip_gap が常に 0.0 になるバグを修正

### DIFF
--- a/src/common/solvers/exact_ilp.py
+++ b/src/common/solvers/exact_ilp.py
@@ -126,12 +126,17 @@ class SolveExactSolution:
         # MIP Gap 計算
         obj_val = L.value()
         mip_gap = None
-        if is_optimal:
+        if is_optimal and ratio_gap is None:
+            # ratioGap なし: CBC が Optimal を返した = 真の最適解
             mip_gap = 0.0
         elif obj_val is not None and obj_val > 0:
+            # ratioGap あり (is_optimal=True の場合を含む) または時間切れの場合
             best_bound = parse_cbc_log_for_bound(log_path)
             if best_bound is not None:
                 mip_gap = (obj_val - best_bound) / obj_val
+            elif is_optimal:
+                # ログからの取得失敗: ratio_gap を上限値として記録
+                mip_gap = ratio_gap
         try:
             os.unlink(log_path)
         except OSError:

--- a/src/common/solvers/ksp_ilp.py
+++ b/src/common/solvers/ksp_ilp.py
@@ -155,12 +155,17 @@ class KspIlpSolver:
         # --- MIP Gap 計算 ---
         alpha_val = pulp.value(alpha) if status_str == 'Optimal' else float('inf')
         mip_gap = None
-        if is_optimal:
+        if is_optimal and self.ratio_gap is None:
+            # ratioGap なし: CBC が Optimal を返した = 真の最適解
             mip_gap = 0.0
         elif alpha_val != float('inf') and alpha_val > 0:
+            # ratioGap あり (is_optimal=True の場合を含む) または時間切れの場合
             best_bound = parse_cbc_log_for_bound(log_path)
             if best_bound is not None:
                 mip_gap = (alpha_val - best_bound) / alpha_val
+            elif is_optimal:
+                # ログからの取得失敗: ratio_gap を上限値として記録
+                mip_gap = self.ratio_gap
         try:
             os.unlink(log_path)
         except OSError:


### PR DESCRIPTION
## 概要

`exact_ilp.py` と `ksp_ilp.py` において、CBC ソルバーに `ratioGap` オプションを指定した場合でも `mip_gap` が常に `0.0` として記録されていたバグを修正。

## 問題の詳細

CBC は `ratioGap=0.05` を指定すると、真の最適値との差が **5%以内** で探索を打ち切り、ステータスを `Optimal` で返す。
しかし修正前のコードは `is_optimal=True` の場合に無条件で `mip_gap = 0.0` を設定していたため、準最適解でも「真の最適解」として CSV に記録されていた。

これにより `nsfnet_c30_rho04` のような `solver_ratio_gap=0.05` を指定するデータセットでは、`exact_solution.csv` の mip_gap 列が全件 `0.0` になっており、RL モデルが「厳密解」を下回る（`data_idx=49`: gt=0.4932, rl=0.4895）ケースが生じていた。

## 修正内容

```
src/common/solvers/exact_ilp.py   # _solve_pulp メソッド内 MIP Gap 計算
src/common/solvers/ksp_ilp.py     # solve メソッド内 MIP Gap 計算
```

| ケース | 修正前 | 修正後 |
|---|---|---|
| `ratio_gap=None`, `is_optimal=True` | `mip_gap = 0.0` | `mip_gap = 0.0`（変わらず・正しい） |
| `ratio_gap=0.05`, `is_optimal=True` | `mip_gap = 0.0`（**バグ**） | CBC ログから実際のギャップを計算 |
| `ratio_gap=0.05`, `is_optimal=True`、ログ取得失敗 | `mip_gap = 0.0`（**バグ**） | `mip_gap = 0.05`（上限値として記録） |
| `is_optimal=False` | CBC ログから計算 | 変わらず |

## 影響範囲

- `ratio_gap=None`（完全厳密解）のデータセットへの影響なし
- `solver_ratio_gap` または `ksp_ilp_ratio_gap` を config で指定しているデータセットで、次回データ生成時から正しい mip_gap が記録される