### PR TITLE
fix: approx rate > 100% を CRITICAL ERROR から WARNING に変更

### DIFF
--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -507,17 +507,12 @@ class RLTrainer:
             # デバッグ情報
             print(f"  Debug: data_idx={current_data_idx}, gt_load={gt_load_factor:.6f}, rl_load={max_load:.6f}, approx_rate={approximation_rate:.2f}%")
 
-            # Approximation Rateが100%を明確に超えた場合のみ異常とみなして強制終了
-            # 浮動小数点の精度を考慮して100.01%以上を異常とする
+            # Approximation Rateが100%を超えた場合: 厳密解がratioGapによる準最適解の可能性があるためワーニングのみ
             if approximation_rate > 100.01:
-                print(f"\n❌ CRITICAL ERROR: Approximation Rate exceeded 100% ({approximation_rate:.2f}%)")
-                print(f"   This indicates a serious data inconsistency or calculation bug.")
-                print(f"   Episode: {episode + 1}/{test_episodes}")
-                print(f"   Data Index: {current_data_idx}")
-                print(f"   GT Load Factor: {gt_load_factor:.6f}")
-                print(f"   RL Max Load: {max_load:.6f}")
-                print(f"\nProgram terminated to prevent invalid results.")
-                exit(1)
+                print(f"\n⚠️  WARNING: Approximation Rate exceeded 100% ({approximation_rate:.2f}%)")
+                print(f"   GT load ({gt_load_factor:.6f}) may be a sub-optimal solution due to solver ratioGap setting.")
+                print(f"   Episode: {episode + 1}/{test_episodes}, Data Index: {current_data_idx}")
+                print(f"   Continuing experiment...")
 
             episode_approx_rates.append(approximation_rate)
             episode_gt_loads.append(gt_load_factor)


### PR DESCRIPTION
## 概要

RL-KSP テスト時に approximation rate が 100% を超えた場合、強制終了（`exit(1)`）していた処理をワーニング表示に変更し、実験を継続できるようにした。

## 背景

今回の mip_gap バグ修正（#78）で明らかになった通り、`solver_ratio_gap` を指定したデータセットでは厳密解ラベルが真の最適解ではなく準最適解（5%ギャップ以内）になりうる。

そのため RL が「厳密解」ラベルを下回るケースは正当に発生しうるものであり、バグではなくラベルの問題。強制終了は不適切。

## 修正内容

`src/rl_ksp/train/rl_trainer.py`

- `❌ CRITICAL ERROR` + `exit(1)` → `⚠️ WARNING` + 継続
- ワーニングメッセージに原因（solver ratioGap による準最適解の可能性）を明記

## 関連

- #78 ratioGap 使用時の mip_gap バグ修正