### PR TITLE
feat: RL-KSP テスト結果に RL 自身の load factor を記録

### DIFF
--- a/src/gcn/train/metrics.py
+++ b/src/gcn/train/metrics.py
@@ -32,6 +32,7 @@ class MetricsLogger:
         self.test_comp_sample_rate_list = []
 
         # Baseline comparison metrics (test only)
+        self.test_avg_rl_load_list = []         # テスト時の平均RL load factor
         self.test_avg_exact_load_list = []      # テスト時の平均厳密解 load factor
         self.test_avg_ksp_ilp_load_list = []    # テスト時の平均KSP-ILPベースライン load factor
         self.test_ksp_ilp_approx_rate_list = [] # KSP-ILPとの近似率 (exact/ksp_ilp*100)
@@ -80,8 +81,8 @@ class MetricsLogger:
 
     def log_test_metrics(self, approximation_rate: float, test_time: float = None, epoch: int = None,
                          comp_rate: float = None, comp_sample_rate: float = None,
-                         avg_exact_load: float = None, avg_ksp_ilp_load: float = None,
-                         ksp_ilp_approx_rate: float = None):
+                         avg_rl_load: float = None, avg_exact_load: float = None,
+                         avg_ksp_ilp_load: float = None, ksp_ilp_approx_rate: float = None):
         """テストメトリクスを記録"""
         self.test_approximation_rate_list.append(approximation_rate)
         if test_time is not None:
@@ -93,6 +94,8 @@ class MetricsLogger:
             self.test_comp_rate_list.append(comp_rate)
         if comp_sample_rate is not None:
             self.test_comp_sample_rate_list.append(comp_sample_rate)
+        if avg_rl_load is not None:
+            self.test_avg_rl_load_list.append(avg_rl_load)
         if avg_exact_load is not None:
             self.test_avg_exact_load_list.append(avg_exact_load)
         if avg_ksp_ilp_load is not None:
@@ -181,6 +184,10 @@ class MetricsLogger:
             'train_time_list': self.train_time_list,
             'val_time_list': self.val_time_list,
             'test_time_list': self.test_time_list,
+            'test_avg_rl_load_list': self.test_avg_rl_load_list,
+            'test_avg_exact_load_list': self.test_avg_exact_load_list,
+            'test_avg_ksp_ilp_load_list': self.test_avg_ksp_ilp_load_list,
+            'test_ksp_ilp_approx_rate_list': self.test_ksp_ilp_approx_rate_list,
             'final_metrics': self.get_final_metrics(),
             'time_per_data': time_per_data,
             'config_info': config_info or {}
@@ -238,6 +245,8 @@ class MetricsLogger:
                     f.write(f"  Final Test Comp Rate: {self.test_comp_rate_list[-1]:.2f}%\n")
                 if self.test_comp_sample_rate_list:
                     f.write(f"  Final Test CompSample Rate: {self.test_comp_sample_rate_list[-1]:.2f}%\n")
+                if self.test_avg_rl_load_list:
+                    f.write(f"  Avg RL Load Factor: {self.test_avg_rl_load_list[-1]:.6f}\n")
                 if self.test_avg_exact_load_list:
                     f.write(f"  Avg Exact Solution Load Factor: {self.test_avg_exact_load_list[-1]:.6f}\n")
                 if self.test_avg_ksp_ilp_load_list:

--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -550,16 +550,17 @@ class RLTrainer:
         # ksp_ilp_approx_rate はエピソード毎の比の平均（同一サンプルで計算）
         ksp_ilp_approx_rate = float(np.mean(episode_ksp_ilp_approx_rates)) if episode_ksp_ilp_approx_rates else None
 
+        # 統計の表示（GCNと同じスタイル）
+        avg_reward = np.mean([r['total_reward'] for r in test_results])
+        avg_max_load = float(np.mean([r['max_load'] for r in test_results]))
+
         self.metrics_logger.log_test_metrics(
             mean_approx_rate, total_test_time,
+            avg_rl_load=avg_max_load,
             avg_exact_load=avg_exact_load,
             avg_ksp_ilp_load=avg_ksp_ilp_load,
             ksp_ilp_approx_rate=ksp_ilp_approx_rate,
         )
-
-        # 統計の表示（GCNと同じスタイル）
-        avg_reward = np.mean([r['total_reward'] for r in test_results])
-        avg_max_load = np.mean([r['max_load'] for r in test_results])
         avg_steps = np.mean([r['steps'] for r in test_results])
         avg_time = total_test_time / test_episodes
 


### PR DESCRIPTION
## 概要

RL-KSP のテスト結果ファイル（`training_results_*.txt` / `.pkl`）に、RL モデル自身が出した load factor の平均値（`Avg RL Load Factor`）が記録されていなかった問題を修正。

## 問題の詳細

`rl_trainer.py` では `avg_max_load` を計算してコンソール表示していたが、`metrics_logger.log_test_metrics()` に渡していなかった。また `MetricsLogger` 側にも RL load factor を保持するフィールドが存在しなかったため、txt/pkl どちらにも出力されていなかった。

## 修正内容

**`src/gcn/train/metrics.py`**
- `__init__`: `test_avg_rl_load_list` フィールドを追加
- `log_test_metrics`: `avg_rl_load` パラメータを追加してリストに格納
- `save_results` (txt): `Avg RL Load Factor` を出力
- `save_results` (pkl): ベースライン系リスト（`test_avg_rl_load_list` 等）を `results` dict に追加

**`src/rl_ksp/train/rl_trainer.py`**
- `avg_max_load` の計算を `log_test_metrics` 呼び出し前に移動
- `avg_rl_load=avg_max_load` を `log_test_metrics` に渡すよう追加

## 出力例（txt）

```
Final Test Approximation Rate: 89.04%
  Avg RL Load Factor: 0.631234          ← 今回追加
  Avg Exact Solution Load Factor: 0.706093
  Avg KSP-ILP Baseline Load Factor: 0.708520
  KSP-ILP Approx Rate (Exact/KSP-ILP): 99.62%
```