### PR TITLE
feat: --skip-exact データへの厳密解後付け計算スクリプトを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,21 @@ python scripts/rl_ksp/train_rl_ksp.py --config configs/rl_ksp/rl_config.json
 python scripts/seq_flow_rl/train_seqflowrl.py --config configs/seqflowrl/seqflowrl_base.json
 ```
 
+### 厳密解後付け計算（--skip-exact で生成したデータ向け）
+```bash
+# skip-exact で生成したデータに厳密解を後付け計算（config の solver_ratio_gap が適用される）
+python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json
+
+# パイロットテスト用: 5件だけ計算して時間見積もり
+python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --num-samples 5
+
+# 強制再計算
+python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --recompute
+
+# time_limit を上書き（config の solver_time_limit より優先）
+python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --time-limit 60
+```
+
 ### KSP-ILP ベースライン事前計算
 ```bash
 # 既存データに対して KSP-ILP を一括計算（train/val/test 全モード）

--- a/README.md
+++ b/README.md
@@ -123,6 +123,49 @@ python scripts/common/generate_data.py --clean-only
 
 ---
 
+#### 厳密解をスキップして生成（大規模コモディティ向け）
+
+```bash
+# --skip-exact: 厳密解の計算をスキップしてグラフと品種のみ生成
+python scripts/common/generate_data.py --config configs/rl_ksp/nsfnet_c30_rho04.json --skip-exact --force
+
+# パイロットテスト用: 少数サンプルだけ生成
+python scripts/common/generate_data.py --config configs/rl_ksp/nsfnet_c30_rho04.json --num-samples 5 --skip-exact --force
+```
+
+#### 厳密解を後付け計算（--skip-exact で生成したデータ向け）
+
+```bash
+# config の solver_ratio_gap / solver_time_limit を適用して後付け計算
+python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json
+
+# パイロットテスト用: 5件だけ計算して時間見積もり
+python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --num-samples 5
+
+# 強制再計算
+python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --recompute
+
+# time_limit を上書き（config の solver_time_limit より優先）
+python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --time-limit 60
+```
+
+> **注意**: `--skip-exact` 時は通常の再生成ループ（`objective_value >= 1.0` の場合にグラフを作り直す処理）をスキップしているため、後付け計算で一部サンプルが `objective_value >= 1.0` になる可能性があります。その場合はワーニングを表示してそのまま記録します。
+
+#### KSP-ILP ベースラインの事前計算
+
+```bash
+# 既存データに対して KSP-ILP を一括計算（train/val/test 全モード）
+python scripts/common/compute_ksp_ilp.py --config configs/gcn/default2.json --K 10
+
+# パイロットテスト用: 少数サンプルだけ計算
+python scripts/common/compute_ksp_ilp.py --config configs/gcn/default2.json --K 10 --num-samples 5
+
+# 強制再計算
+python scripts/common/compute_ksp_ilp.py --config configs/gcn/default2.json --K 10 --recompute
+```
+
+---
+
 ### 2. GCN実験
 
 #### 基本的な学習+テスト（一括実行）

--- a/scripts/common/compute_exact_solution.py
+++ b/scripts/common/compute_exact_solution.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""--skip-exact で生成したデータセットに厳密解を後付け計算するスクリプト.
+
+既存の graph_*.gml + commodity_*.csv を読み込み、SolveExactSolution を実行して
+exact_solution.csv を生成・追記する。config の solver_ratio_gap / solver_time_limit
+がそのまま適用される。
+
+使い方:
+    # 全モード後付け計算
+    python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json
+
+    # パイロット: 5件だけ計算して時間見積もり
+    python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --num-samples 5
+
+    # 既存 CSV を削除して再計算
+    python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --recompute
+
+    # time_limit を上書き
+    python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --time-limit 60
+"""
+
+import sys
+import os
+import csv
+import argparse
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from src.common.config.config_manager import ConfigManager
+from src.common.config.paths import (
+    get_exact_solution_file,
+    get_graph_file,
+    get_commodity_file,
+    get_mode_dir,
+    BUCKET_SIZE,
+)
+from src.common.solvers.exact_ilp import SolveExactSolution
+
+
+def compute_exact_solutions(config, mode: str, num_data: int,
+                             time_limit: int, ratio_gap, recompute: bool = False):
+    """既存データに対して厳密解を後付け計算し exact_solution.csv に保存する.
+
+    Args:
+        config: ConfigManager から取得した設定オブジェクト
+        mode: 'train' / 'val' / 'test'
+        num_data: 対象サンプル数
+        time_limit: ILP ソルバーの制限時間 [秒]
+        ratio_gap: CBC の ratioGap オプション（None なら真の最適解を要求）
+        recompute: True なら既存 CSV を削除して最初から計算
+    """
+    solver_type = getattr(config, 'solver_type', 'pulp')
+    exact_file = get_exact_solution_file(mode, config)
+
+    if recompute and exact_file.exists():
+        exact_file.unlink()
+        print(f"[{mode}] 既存 CSV を削除: {exact_file}")
+
+    # 再開サポート: 既存行数分はスキップ
+    start_index = 0
+    if exact_file.exists():
+        try:
+            with open(exact_file, 'r') as f:
+                start_index = sum(1 for _ in csv.reader(f))
+        except Exception:
+            start_index = 0
+
+    if start_index >= num_data:
+        print(f"[{mode}] 全 {num_data} 件計算済み。スキップ。")
+        return
+
+    if start_index > 0:
+        print(f"[{mode}] {start_index}/{num_data} 件完了済み。{start_index} から再開。")
+
+    gap_str = f"ratioGap={ratio_gap}" if ratio_gap is not None else "厳密最適"
+    print(f"[{mode}] {num_data - start_index} 件計算開始 (time_limit={time_limit}s, {gap_str})")
+
+    skipped = 0
+    warned = 0
+
+    for i in range(start_index, num_data):
+        graph_file = get_graph_file(mode, i, config)
+        commodity_file = get_commodity_file(mode, i, config)
+
+        if not graph_file.exists() or not commodity_file.exists():
+            print(f"  [{mode}:{i}] ファイルが存在しません。スキップ。"
+                  f" graph={graph_file.exists()} commodity={commodity_file.exists()}")
+            # CSV の行数を合わせるため NaN 行を書く
+            with open(exact_file, 'a', newline='') as f:
+                csv.writer(f).writerow([None, None, None])
+            skipped += 1
+            continue
+
+        try:
+            solver = SolveExactSolution(solver_type, str(commodity_file), str(graph_file))
+            _, _, obj_val, elapsed_time, is_optimal, mip_gap = solver.solve_exact_solution_to_env(
+                time_limit=time_limit, ratio_gap=ratio_gap
+            )
+        except Exception as e:
+            print(f"  [{mode}:{i}] エラー: {e}")
+            with open(exact_file, 'a', newline='') as f:
+                csv.writer(f).writerow([None, None, None])
+            skipped += 1
+            continue
+
+        if obj_val is None or obj_val >= 1.0:
+            print(f"  ⚠️  [{mode}:{i}] obj_val={obj_val} (>= 1.0 または None)。"
+                  f" --skip-exact 時の再生成ループをスキップしたサンプルの可能性。そのまま記録。")
+            warned += 1
+
+        with open(exact_file, 'a', newline='') as f:
+            csv.writer(f).writerow([obj_val, elapsed_time, mip_gap])
+
+        if i % BUCKET_SIZE == 0:
+            gap_info = f", Gap={mip_gap:.4f}" if mip_gap is not None else ""
+            opt_mark = "✓" if is_optimal else "~"
+            print(f"  {opt_mark} [{mode}:{i}/{num_data}] MLU={obj_val:.6f}{gap_info} ({elapsed_time:.1f}s)")
+
+    print(f"[{mode}] 完了: {num_data} 件 (スキップ={skipped}, 警告={warned})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='--skip-exact データへの厳密解後付け計算')
+    parser.add_argument('--config', type=str, required=True, help='設定ファイルのパス')
+    parser.add_argument('--modes', type=str, nargs='+', default=['train', 'val', 'test'],
+                        choices=['train', 'val', 'test'], help='対象モード (default: train val test)')
+    parser.add_argument('--time-limit', type=int, default=None,
+                        help='ILP ソルバー制限時間 [秒]（省略時は config の solver_time_limit を使用）')
+    parser.add_argument('--recompute', action='store_true',
+                        help='既存の exact_solution.csv を削除して最初から計算')
+    parser.add_argument('--num-samples', type=int, default=None,
+                        help='パイロットテスト用: 指定数だけ計算して時間を見積もる')
+    args = parser.parse_args()
+
+    print("\n" + "=" * 60)
+    print("EXACT SOLUTION POST-COMPUTATION")
+    print("=" * 60)
+
+    config_manager = ConfigManager(args.config)
+    config = config_manager.get_config()
+
+    solver_time_limit = args.time_limit if args.time_limit is not None else getattr(config, 'solver_time_limit', 30)
+    ratio_gap = getattr(config, 'solver_ratio_gap', None)
+
+    print(f"  Config:      {args.config}")
+    print(f"  Solver:      {getattr(config, 'solver_type', 'pulp')}")
+    print(f"  Time limit:  {solver_time_limit}s")
+    print(f"  Ratio gap:   {ratio_gap if ratio_gap is not None else '未指定（厳密最適）'}")
+    if args.num_samples:
+        print(f"  Pilot test:  {args.num_samples} samples only")
+
+    for mode in args.modes:
+        mode_dir = get_mode_dir(mode, config)
+        if not mode_dir.exists():
+            print(f"\n[{mode}] ディレクトリが存在しません。スキップ。")
+            continue
+
+        num_data = getattr(config, f'num_{mode}_data', 0)
+        if num_data == 0:
+            print(f"\n[{mode}] num_{mode}_data=0。スキップ。")
+            continue
+
+        effective_num = min(num_data, args.num_samples) if args.num_samples else num_data
+        print(f"\n[{mode}] {effective_num}/{num_data} 件")
+
+        compute_exact_solutions(
+            config, mode, effective_num,
+            time_limit=solver_time_limit,
+            ratio_gap=ratio_gap,
+            recompute=args.recompute,
+        )
+
+    print("\n" + "=" * 60)
+    print("DONE")
+    print("=" * 60)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## 概要

`--skip-exact` で生成したデータセットに対して、厳密解（`exact_solution.csv`）を後付けで計算するスクリプト `scripts/common/compute_exact_solution.py` を追加。

## 背景

大規模コモディティ（C≥30 など）ではデータ生成時に `--skip-exact` を使って厳密解の計算を省略することがある。しかし、`solver_ratio_gap`（MIP Gap）を適用すれば実行時間内に厳密解を求められるケースもある。本スクリプトはその後付け計算を `compute_ksp_ilp.py` と同じパターンで提供する。

## 追加ファイル

**`scripts/common/compute_exact_solution.py`**

```bash
# 基本（config の solver_ratio_gap / solver_time_limit を適用）
python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json

# パイロット（5件で時間見積もり）
python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --num-samples 5

# 強制再計算
python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --recompute

# time_limit を上書き
python scripts/common/compute_exact_solution.py --config configs/rl_ksp/nsfnet_c30_rho04.json --time-limit 60
```

## 設計ポイント

| 機能 | 詳細 |
|---|---|
| ratio_gap 適用 | config の `solver_ratio_gap` を自動取得して CBC に渡す |
| 再開サポート | `exact_solution.csv` の既存行数をカウントして途中から再開 |
| ファイル欠損対応 | graph/commodity が存在しない場合は `None,None,None` を記録してインデックスを保持 |
| obj≥1.0 の警告 | 再生成ループを経ていないサンプルへの警告表示（実験は継続） |

## ドキュメント更新

- `CLAUDE.md`: 厳密解後付け計算コマンドを追加
- `README.md`: データ生成セクションに後付け計算・KSP-ILP 事前計算の説明を追加