### PR TITLE
refactor: MetricsLogger 分割 + RL-KSP ベースライン近似率改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ repomix-output.xml
 saved_models/*.pt
 saved_models/*.pth
 
+# Claude Code のローカル状態（コミット不要）
+.claude/
+
 # macOS 特有のメタファイルを無視
 __MACOSX/
 *.DS_Store

--- a/src/common/train/__init__.py
+++ b/src/common/train/__init__.py
@@ -1,0 +1,3 @@
+from .base_metrics import BaseMetricsLogger
+
+__all__ = ['BaseMetricsLogger']

--- a/src/common/train/base_metrics.py
+++ b/src/common/train/base_metrics.py
@@ -1,0 +1,68 @@
+import os
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Optional
+
+
+class BaseMetricsLogger(ABC):
+    """GCN・RL-KSP 共通のメトリクス記録基底クラス"""
+
+    def __init__(self, save_dir: str = "logs"):
+        self.val_approximation_rate_list = []
+        self.test_approximation_rate_list = []
+
+        self.train_time_list = []
+        self.val_time_list = []
+        self.test_time_list = []
+        self.total_train_time = 0.0
+        self.total_test_time = 0.0
+
+        self.val_epochs = []
+        self.test_epochs = []
+
+        self.save_dir = save_dir
+        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+        os.makedirs(self.save_dir, exist_ok=True)
+
+    def log_val_metrics(self, approximation_rate: float, val_time: Optional[float] = None,
+                        epoch: Optional[int] = None):
+        """検証メトリクスの共通フィールドを記録"""
+        self.val_approximation_rate_list.append(approximation_rate)
+        if val_time is not None:
+            self.val_time_list.append(val_time)
+        if epoch is not None:
+            self.val_epochs.append(epoch)
+
+    def log_test_metrics(self, approximation_rate: float, test_time: Optional[float] = None,
+                         epoch: Optional[int] = None):
+        """テストメトリクスの共通フィールドを記録"""
+        self.test_approximation_rate_list.append(approximation_rate)
+        if test_time is not None:
+            self.test_time_list.append(test_time)
+            self.total_test_time += test_time
+        if epoch is not None:
+            self.test_epochs.append(epoch)
+
+    def calculate_time_per_data(self, num_train_data: int, num_test_data: int) -> dict:
+        """1データあたりの経過時間を計算"""
+        total_train_samples = num_train_data * len(self.train_time_list) if self.train_time_list else 0
+        total_test_samples = num_test_data * len(self.test_time_list) if self.test_time_list else 0
+        return {
+            'train_time_per_data': self.total_train_time / total_train_samples if total_train_samples > 0 else 0.0,
+            'test_time_per_data': self.total_test_time / total_test_samples if total_test_samples > 0 else 0.0,
+            'total_train_samples': total_train_samples,
+            'total_test_samples': total_test_samples,
+        }
+
+    @abstractmethod
+    def get_final_metrics(self) -> dict:
+        """最終メトリクスを返す（サブクラスで実装）"""
+
+    @abstractmethod
+    def save_results(self, config_info: Optional[dict] = None):
+        """結果をファイルに保存（サブクラスで実装）"""
+
+    @abstractmethod
+    def print_summary(self, config_info: Optional[dict] = None):
+        """サマリーを表示（サブクラスで実装）"""

--- a/src/gcn/train/__init__.py
+++ b/src/gcn/train/__init__.py
@@ -1,5 +1,5 @@
 from .trainer import Trainer
 from .evaluator import Evaluator
-from .metrics import MetricsLogger
+from .metrics import GCNMetricsLogger, MetricsLogger
 
-__all__ = ['Trainer', 'Evaluator', 'MetricsLogger'] 
+__all__ = ['Trainer', 'Evaluator', 'GCNMetricsLogger', 'MetricsLogger'] 

--- a/src/gcn/train/metrics.py
+++ b/src/gcn/train/metrics.py
@@ -32,10 +32,11 @@ class MetricsLogger:
         self.test_comp_sample_rate_list = []
 
         # Baseline comparison metrics (test only)
-        self.test_avg_rl_load_list = []         # テスト時の平均RL load factor
-        self.test_avg_exact_load_list = []      # テスト時の平均厳密解 load factor
-        self.test_avg_ksp_ilp_load_list = []    # テスト時の平均KSP-ILPベースライン load factor
-        self.test_ksp_ilp_approx_rate_list = [] # KSP-ILPとの近似率 (exact/ksp_ilp*100)
+        self.test_avg_rl_load_list = []          # テスト時の平均RL load factor
+        self.test_avg_exact_load_list = []       # テスト時の平均厳密解 load factor
+        self.test_avg_ksp_ilp_load_list = []     # テスト時の平均KSP-ILPベースライン load factor
+        self.test_ksp_ilp_approx_rate_list = []  # KSP-ILPとの近似率 (exact/ksp_ilp*100)
+        self.test_exact_approx_rate_list = []    # 厳密解ベースの近似率 (exact/rl*100)
 
         # RL-specific metrics (existing)
         self.rl_reward_list = []
@@ -82,7 +83,8 @@ class MetricsLogger:
     def log_test_metrics(self, approximation_rate: float, test_time: float = None, epoch: int = None,
                          comp_rate: float = None, comp_sample_rate: float = None,
                          avg_rl_load: float = None, avg_exact_load: float = None,
-                         avg_ksp_ilp_load: float = None, ksp_ilp_approx_rate: float = None):
+                         avg_ksp_ilp_load: float = None, ksp_ilp_approx_rate: float = None,
+                         exact_approx_rate: float = None):
         """テストメトリクスを記録"""
         self.test_approximation_rate_list.append(approximation_rate)
         if test_time is not None:
@@ -102,6 +104,8 @@ class MetricsLogger:
             self.test_avg_ksp_ilp_load_list.append(avg_ksp_ilp_load)
         if ksp_ilp_approx_rate is not None:
             self.test_ksp_ilp_approx_rate_list.append(ksp_ilp_approx_rate)
+        if exact_approx_rate is not None:
+            self.test_exact_approx_rate_list.append(exact_approx_rate)
 
     def log_rl_metrics(self, epoch: int, rl_metrics: dict):
         """RL特有のメトリクスを記録"""
@@ -188,6 +192,7 @@ class MetricsLogger:
             'test_avg_exact_load_list': self.test_avg_exact_load_list,
             'test_avg_ksp_ilp_load_list': self.test_avg_ksp_ilp_load_list,
             'test_ksp_ilp_approx_rate_list': self.test_ksp_ilp_approx_rate_list,
+            'test_exact_approx_rate_list': self.test_exact_approx_rate_list,
             'final_metrics': self.get_final_metrics(),
             'time_per_data': time_per_data,
             'config_info': config_info or {}
@@ -247,12 +252,21 @@ class MetricsLogger:
                     f.write(f"  Final Test CompSample Rate: {self.test_comp_sample_rate_list[-1]:.2f}%\n")
                 if self.test_avg_rl_load_list:
                     f.write(f"  Avg RL Load Factor: {self.test_avg_rl_load_list[-1]:.6f}\n")
+                if self.test_avg_ksp_ilp_load_list:
+                    f.write(f"  Avg KSP-ILP Load Factor: {self.test_avg_ksp_ilp_load_list[-1]:.6f}\n")
+                f.write(f"  Approx Rate (KSP-ILP base): {metrics['final_test_approximation_rate']:.2f}%\n")
+                if self.test_exact_approx_rate_list:
+                    f.write(f"  Approx Rate (Exact base): {self.test_exact_approx_rate_list[-1]:.2f}%\n")
+                else:
+                    f.write(f"  Approx Rate (Exact base): N/A\n")
                 if self.test_avg_exact_load_list:
                     f.write(f"  Avg Exact Solution Load Factor: {self.test_avg_exact_load_list[-1]:.6f}\n")
-                if self.test_avg_ksp_ilp_load_list:
-                    f.write(f"  Avg KSP-ILP Baseline Load Factor: {self.test_avg_ksp_ilp_load_list[-1]:.6f}\n")
+                else:
+                    f.write(f"  Avg Exact Solution Load Factor: N/A\n")
                 if self.test_ksp_ilp_approx_rate_list:
                     f.write(f"  KSP-ILP Approx Rate (Exact/KSP-ILP): {self.test_ksp_ilp_approx_rate_list[-1]:.2f}%\n")
+                else:
+                    f.write(f"  KSP-ILP Approx Rate (Exact/KSP-ILP): N/A\n")
             
             # 時間関連のメトリクス
             f.write("\nTIME METRICS:\n")

--- a/src/gcn/train/metrics.py
+++ b/src/gcn/train/metrics.py
@@ -2,28 +2,19 @@ import numpy as np
 import pickle
 import os
 import torch
-from datetime import datetime
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Optional
 
-class MetricsLogger:
-    """メトリクスの記録と出力を管理するクラス"""
-    
+from src.common.train.base_metrics import BaseMetricsLogger
+
+
+class GCNMetricsLogger(BaseMetricsLogger):
+    """GCN 用メトリクス記録クラス"""
+
     def __init__(self, save_dir: str = "logs"):
+        super().__init__(save_dir)
+
         self.train_loss_list = []
         self.train_err_edges_list = []
-        self.val_approximation_rate_list = []
-        self.test_approximation_rate_list = []
-
-        # 時間関連のメトリクスを追加
-        self.train_time_list = []
-        self.val_time_list = []
-        self.test_time_list = []
-        self.total_train_time = 0.0
-        self.total_test_time = 0.0
-
-        # エポック番号の記録を追加
-        self.val_epochs = []  # バリデーションを実行したエポック番号
-        self.test_epochs = []  # テストを実行したエポック番号
 
         # Comp% / CompSample% lists
         self.val_comp_rate_list = []
@@ -31,35 +22,22 @@ class MetricsLogger:
         self.test_comp_rate_list = []
         self.test_comp_sample_rate_list = []
 
-        # Baseline comparison metrics (test only)
-        self.test_avg_rl_load_list = []          # テスト時の平均RL load factor
-        self.test_avg_exact_load_list = []       # テスト時の平均厳密解 load factor
-        self.test_avg_ksp_ilp_load_list = []     # テスト時の平均KSP-ILPベースライン load factor
-        self.test_ksp_ilp_approx_rate_list = []  # KSP-ILPとの近似率 (exact/ksp_ilp*100)
-        self.test_exact_approx_rate_list = []    # 厳密解ベースの近似率 (exact/rl*100)
-
-        # RL-specific metrics (existing)
+        # RL-specific metrics (GCN の RL 学習戦略向け)
         self.rl_reward_list = []
         self.rl_advantage_list = []
         self.rl_entropy_list = []
         self.rl_load_factor_list = []
         self.rl_baseline_list = []
 
-        # RL-specific metrics (new - path quality)
-        self.rl_complete_paths_rate_list = []  # パス完成率
-        self.rl_finite_solution_rate_list = []  # 有限解の割合
-        self.rl_avg_finite_load_factor_list = []  # 有限解の平均負荷率
-        self.rl_avg_path_length_list = []  # 平均パス長
-        self.rl_commodity_success_rate_list = []  # コモディティ成功率
-        self.rl_capacity_violation_rate_list = []  # 容量違反率
-
-        self.save_dir = save_dir
-        self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-
-        # 保存ディレクトリの作成
-        os.makedirs(self.save_dir, exist_ok=True)
+        # RL-specific metrics (path quality)
+        self.rl_complete_paths_rate_list = []
+        self.rl_finite_solution_rate_list = []
+        self.rl_avg_finite_load_factor_list = []
+        self.rl_avg_path_length_list = []
+        self.rl_commodity_success_rate_list = []
+        self.rl_capacity_violation_rate_list = []
     
-    def log_train_metrics(self, loss: float, edge_error: float, train_time: float = None):
+    def log_train_metrics(self, loss: float, edge_error: float, train_time: Optional[float] = None):
         """トレーニングメトリクスを記録"""
         self.train_loss_list.append(loss)
         self.train_err_edges_list.append(edge_error)
@@ -67,45 +45,25 @@ class MetricsLogger:
             self.train_time_list.append(train_time)
             self.total_train_time += train_time
     
-    def log_val_metrics(self, approximation_rate: float, val_time: float = None, epoch: int = None,
-                        comp_rate: float = None, comp_sample_rate: float = None):
+    def log_val_metrics(self, approximation_rate: float, val_time: Optional[float] = None,
+                        epoch: Optional[int] = None, comp_rate: Optional[float] = None,
+                        comp_sample_rate: Optional[float] = None):
         """検証メトリクスを記録"""
-        self.val_approximation_rate_list.append(approximation_rate)
-        if val_time is not None:
-            self.val_time_list.append(val_time)
-        if epoch is not None:
-            self.val_epochs.append(epoch)
+        super().log_val_metrics(approximation_rate, val_time, epoch)
         if comp_rate is not None:
             self.val_comp_rate_list.append(comp_rate)
         if comp_sample_rate is not None:
             self.val_comp_sample_rate_list.append(comp_sample_rate)
 
-    def log_test_metrics(self, approximation_rate: float, test_time: float = None, epoch: int = None,
-                         comp_rate: float = None, comp_sample_rate: float = None,
-                         avg_rl_load: float = None, avg_exact_load: float = None,
-                         avg_ksp_ilp_load: float = None, ksp_ilp_approx_rate: float = None,
-                         exact_approx_rate: float = None):
+    def log_test_metrics(self, approximation_rate: float, test_time: Optional[float] = None,
+                         epoch: Optional[int] = None, comp_rate: Optional[float] = None,
+                         comp_sample_rate: Optional[float] = None):
         """テストメトリクスを記録"""
-        self.test_approximation_rate_list.append(approximation_rate)
-        if test_time is not None:
-            self.test_time_list.append(test_time)
-            self.total_test_time += test_time
-        if epoch is not None:
-            self.test_epochs.append(epoch)
+        super().log_test_metrics(approximation_rate, test_time, epoch)
         if comp_rate is not None:
             self.test_comp_rate_list.append(comp_rate)
         if comp_sample_rate is not None:
             self.test_comp_sample_rate_list.append(comp_sample_rate)
-        if avg_rl_load is not None:
-            self.test_avg_rl_load_list.append(avg_rl_load)
-        if avg_exact_load is not None:
-            self.test_avg_exact_load_list.append(avg_exact_load)
-        if avg_ksp_ilp_load is not None:
-            self.test_avg_ksp_ilp_load_list.append(avg_ksp_ilp_load)
-        if ksp_ilp_approx_rate is not None:
-            self.test_ksp_ilp_approx_rate_list.append(ksp_ilp_approx_rate)
-        if exact_approx_rate is not None:
-            self.test_exact_approx_rate_list.append(exact_approx_rate)
 
     def log_rl_metrics(self, epoch: int, rl_metrics: dict):
         """RL特有のメトリクスを記録"""
@@ -158,19 +116,6 @@ class MetricsLogger:
             'avg_test_time_per_epoch': np.mean(self.test_time_list) if self.test_time_list else 0.0
         }
     
-    def calculate_time_per_data(self, num_train_data: int, num_test_data: int) -> dict:
-        """一つのデータあたりの経過時間を計算"""
-        total_train_samples = num_train_data * len(self.train_time_list) if self.train_time_list else 0
-        total_test_samples = num_test_data * len(self.test_time_list) if self.test_time_list else 0
-        
-        time_per_data = {
-            'train_time_per_data': self.total_train_time / total_train_samples if total_train_samples > 0 else 0.0,
-            'test_time_per_data': self.total_test_time / total_test_samples if total_test_samples > 0 else 0.0,
-            'total_train_samples': total_train_samples,
-            'total_test_samples': total_test_samples
-        }
-        return time_per_data
-    
     def save_results(self, config_info: dict = None):
         """結果をファイルに保存"""
         # 時間関連の計算
@@ -188,11 +133,6 @@ class MetricsLogger:
             'train_time_list': self.train_time_list,
             'val_time_list': self.val_time_list,
             'test_time_list': self.test_time_list,
-            'test_avg_rl_load_list': self.test_avg_rl_load_list,
-            'test_avg_exact_load_list': self.test_avg_exact_load_list,
-            'test_avg_ksp_ilp_load_list': self.test_avg_ksp_ilp_load_list,
-            'test_ksp_ilp_approx_rate_list': self.test_ksp_ilp_approx_rate_list,
-            'test_exact_approx_rate_list': self.test_exact_approx_rate_list,
             'final_metrics': self.get_final_metrics(),
             'time_per_data': time_per_data,
             'config_info': config_info or {}
@@ -244,29 +184,12 @@ class MetricsLogger:
                 if self.val_comp_sample_rate_list:
                     f.write(f"  Final Val CompSample Rate: {self.val_comp_sample_rate_list[-1]:.2f}%\n")
             if self.test_approximation_rate_list:
-                f.write(f"  Final Test Approximation Rate: {metrics['final_test_approximation_rate']:.2f}%\n")
-                f.write(f"  Best Test Approximation Rate: {metrics['best_test_approximation_rate']:.2f}%\n")
+                f.write(f"  Avg Test Approx Rate (Exact base): {metrics['final_test_approximation_rate']:.2f}%\n")
+                f.write(f"  Best Test Approx Rate (Exact base): {metrics['best_test_approximation_rate']:.2f}%\n")
                 if self.test_comp_rate_list:
                     f.write(f"  Final Test Comp Rate: {self.test_comp_rate_list[-1]:.2f}%\n")
                 if self.test_comp_sample_rate_list:
                     f.write(f"  Final Test CompSample Rate: {self.test_comp_sample_rate_list[-1]:.2f}%\n")
-                if self.test_avg_rl_load_list:
-                    f.write(f"  Avg RL Load Factor: {self.test_avg_rl_load_list[-1]:.6f}\n")
-                if self.test_avg_ksp_ilp_load_list:
-                    f.write(f"  Avg KSP-ILP Load Factor: {self.test_avg_ksp_ilp_load_list[-1]:.6f}\n")
-                f.write(f"  Approx Rate (KSP-ILP base): {metrics['final_test_approximation_rate']:.2f}%\n")
-                if self.test_exact_approx_rate_list:
-                    f.write(f"  Approx Rate (Exact base): {self.test_exact_approx_rate_list[-1]:.2f}%\n")
-                else:
-                    f.write(f"  Approx Rate (Exact base): N/A\n")
-                if self.test_avg_exact_load_list:
-                    f.write(f"  Avg Exact Solution Load Factor: {self.test_avg_exact_load_list[-1]:.6f}\n")
-                else:
-                    f.write(f"  Avg Exact Solution Load Factor: N/A\n")
-                if self.test_ksp_ilp_approx_rate_list:
-                    f.write(f"  KSP-ILP Approx Rate (Exact/KSP-ILP): {self.test_ksp_ilp_approx_rate_list[-1]:.2f}%\n")
-                else:
-                    f.write(f"  KSP-ILP Approx Rate (Exact/KSP-ILP): N/A\n")
             
             # 時間関連のメトリクス
             f.write("\nTIME METRICS:\n")
@@ -497,6 +420,10 @@ def print_training_summary(results: dict):
         print(f"\nConfig File: {config_info.get('config_file', 'Unknown')}")
         print(f"Max Epochs: {config_info.get('max_epochs', 'Unknown')}")
         print(f"Learning Rate: {config_info.get('initial_learning_rate', 'Unknown')}")
+
+
+# 後方互換エイリアス
+MetricsLogger = GCNMetricsLogger
 
 # 使用例:
 # results = load_training_results("logs/training_results_20241201_143022.pkl")

--- a/src/rl_ksp/train/metrics.py
+++ b/src/rl_ksp/train/metrics.py
@@ -1,0 +1,190 @@
+import numpy as np
+import pickle
+import os
+from typing import Optional
+
+from src.common.train.base_metrics import BaseMetricsLogger
+
+
+class RLKSPMetricsLogger(BaseMetricsLogger):
+    """RL-KSP 用メトリクス記録クラス"""
+
+    def __init__(self, save_dir: str = "logs"):
+        super().__init__(save_dir)
+
+        # エピソード単位の学習メトリクス
+        self.train_loss_list = []
+        self.episode_reward_list = []
+
+        # テスト時のベースライン比較メトリクス
+        self.test_avg_rl_load_list = []
+        self.test_avg_exact_load_list = []
+        self.test_avg_ksp_ilp_load_list = []
+        self.test_ksp_ilp_approx_rate_list = []
+        self.test_exact_approx_rate_list = []
+
+    def log_train_metrics(self, loss: float, episode_reward: float,
+                          train_time: Optional[float] = None):
+        """エピソード単位の学習メトリクスを記録"""
+        self.train_loss_list.append(loss)
+        self.episode_reward_list.append(episode_reward)
+        if train_time is not None:
+            self.train_time_list.append(train_time)
+            self.total_train_time += train_time
+
+    def log_val_metrics(self, *args, **kwargs):
+        """RL-KSP は検証フェーズを持たないため no-op"""
+
+    def log_test_metrics(self, approximation_rate: float, test_time: Optional[float] = None,
+                         epoch: Optional[int] = None, avg_rl_load: Optional[float] = None,
+                         avg_exact_load: Optional[float] = None,
+                         avg_ksp_ilp_load: Optional[float] = None,
+                         ksp_ilp_approx_rate: Optional[float] = None,
+                         exact_approx_rate: Optional[float] = None):
+        """テストメトリクスを記録"""
+        super().log_test_metrics(approximation_rate, test_time, epoch)
+        if avg_rl_load is not None:
+            self.test_avg_rl_load_list.append(avg_rl_load)
+        if avg_exact_load is not None:
+            self.test_avg_exact_load_list.append(avg_exact_load)
+        if avg_ksp_ilp_load is not None:
+            self.test_avg_ksp_ilp_load_list.append(avg_ksp_ilp_load)
+        if ksp_ilp_approx_rate is not None:
+            self.test_ksp_ilp_approx_rate_list.append(ksp_ilp_approx_rate)
+        if exact_approx_rate is not None:
+            self.test_exact_approx_rate_list.append(exact_approx_rate)
+
+    def get_final_metrics(self) -> dict:
+        """最終メトリクスを返す（Final/Best 命名なし）"""
+        return {
+            'avg_test_approx_rate': self.test_approximation_rate_list[-1] if self.test_approximation_rate_list else 0.0,
+            'avg_rl_load': self.test_avg_rl_load_list[-1] if self.test_avg_rl_load_list else None,
+            'avg_ksp_ilp_load': self.test_avg_ksp_ilp_load_list[-1] if self.test_avg_ksp_ilp_load_list else None,
+            'avg_exact_load': self.test_avg_exact_load_list[-1] if self.test_avg_exact_load_list else None,
+            'ksp_ilp_approx_rate': self.test_ksp_ilp_approx_rate_list[-1] if self.test_ksp_ilp_approx_rate_list else None,
+            'exact_approx_rate': self.test_exact_approx_rate_list[-1] if self.test_exact_approx_rate_list else None,
+            'total_train_time': self.total_train_time,
+            'total_test_time': self.total_test_time,
+            'avg_episode_time': np.mean(self.train_time_list) if self.train_time_list else 0.0,
+            'avg_test_time': np.mean(self.test_time_list) if self.test_time_list else 0.0,
+        }
+
+    def save_results(self, config_info: Optional[dict] = None):
+        """結果をファイルに保存"""
+        num_train_data = config_info.get('num_train_data', 0) if config_info else 0
+        num_test_data = config_info.get('num_test_data', 0) if config_info else 0
+        time_per_data = self.calculate_time_per_data(num_train_data, num_test_data)
+
+        results = {
+            'timestamp': self.timestamp,
+            'train_loss_list': self.train_loss_list,
+            'episode_reward_list': self.episode_reward_list,
+            'test_approximation_rate_list': self.test_approximation_rate_list,
+            'test_avg_rl_load_list': self.test_avg_rl_load_list,
+            'test_avg_exact_load_list': self.test_avg_exact_load_list,
+            'test_avg_ksp_ilp_load_list': self.test_avg_ksp_ilp_load_list,
+            'test_ksp_ilp_approx_rate_list': self.test_ksp_ilp_approx_rate_list,
+            'test_exact_approx_rate_list': self.test_exact_approx_rate_list,
+            'train_time_list': self.train_time_list,
+            'test_time_list': self.test_time_list,
+            'final_metrics': self.get_final_metrics(),
+            'time_per_data': time_per_data,
+            'config_info': config_info or {},
+        }
+
+        pickle_filename = os.path.join(self.save_dir, f"training_results_{self.timestamp}.pkl")
+        try:
+            with open(pickle_filename, 'wb') as f:
+                pickle.dump(results, f)
+            print(f"Results saved to Pickle: {pickle_filename}")
+        except Exception as e:
+            print(f"Pickle save error: {e}")
+            simplified = {
+                'timestamp': self.timestamp,
+                'train_loss_list': self.train_loss_list,
+                'test_approximation_rate_list': self.test_approximation_rate_list,
+                'final_metrics': self.get_final_metrics(),
+                'config_info': {'config_file': config_info.get('config_file', 'unknown') if config_info else 'unknown'},
+            }
+            with open(pickle_filename, 'wb') as f:
+                pickle.dump(simplified, f)
+            print(f"Simplified results saved to Pickle: {pickle_filename}")
+
+        txt_filename = os.path.join(self.save_dir, f"training_results_{self.timestamp}.txt")
+        metrics = self.get_final_metrics()
+        with open(txt_filename, 'w', encoding='utf-8') as f:
+            f.write("=" * 50 + "\n")
+            f.write("RL-KSP TRAINING/EVALUATION RESULTS\n")
+            f.write("=" * 50 + "\n")
+            f.write(f"Timestamp: {self.timestamp}\n")
+            f.write(f"Mode: {config_info.get('mode', 'unknown') if config_info else 'unknown'}\n")
+            f.write(f"Config File: {config_info.get('config_file', 'unknown') if config_info else 'unknown'}\n\n")
+
+            f.write("TEST METRICS:\n")
+            if self.test_approximation_rate_list:
+                f.write(f"  Avg Test Approx Rate (KSP-ILP base): {metrics['avg_test_approx_rate']:.2f}%\n")
+            if metrics['exact_approx_rate'] is not None:
+                f.write(f"  Avg Test Approx Rate (Exact base): {metrics['exact_approx_rate']:.2f}%\n")
+            else:
+                f.write(f"  Avg Test Approx Rate (Exact base): N/A\n")
+            if metrics['avg_rl_load'] is not None:
+                f.write(f"  Avg RL Load Factor: {metrics['avg_rl_load']:.6f}\n")
+            if metrics['avg_ksp_ilp_load'] is not None:
+                f.write(f"  Avg KSP-ILP Load Factor: {metrics['avg_ksp_ilp_load']:.6f}\n")
+            if metrics['avg_exact_load'] is not None:
+                f.write(f"  Avg Exact Solution Load Factor: {metrics['avg_exact_load']:.6f}\n")
+            else:
+                f.write(f"  Avg Exact Solution Load Factor: N/A\n")
+            if metrics['ksp_ilp_approx_rate'] is not None:
+                f.write(f"  KSP-ILP Approx Rate (Exact/KSP-ILP): {metrics['ksp_ilp_approx_rate']:.2f}%\n")
+            else:
+                f.write(f"  KSP-ILP Approx Rate (Exact/KSP-ILP): N/A\n")
+
+            f.write("\nTIME METRICS:\n")
+            f.write(f"  Total Training Time: {metrics['total_train_time']:.2f}s\n")
+            f.write(f"  Total Test Time: {metrics['total_test_time']:.2f}s\n")
+            f.write(f"  Average Time per Episode: {metrics['avg_episode_time']:.2f}s\n")
+            f.write(f"  Test Time per Data: {time_per_data['test_time_per_data']:.4f}s\n")
+            f.write(f"  Total Test Samples: {time_per_data['total_test_samples']}\n")
+
+            f.write("\n" + "=" * 50 + "\n")
+            f.write("EPISODE TRAINING SUMMARY\n")
+            f.write("=" * 50 + "\n")
+            f.write(f"Total Episodes: {len(self.train_loss_list)}\n")
+            if self.train_loss_list:
+                f.write(f"  Final Episode Loss: {self.train_loss_list[-1]:.6f}\n")
+                f.write(f"  Avg Episode Loss: {np.mean(self.train_loss_list):.6f}\n")
+            if self.episode_reward_list:
+                f.write(f"  Final Episode Reward: {self.episode_reward_list[-1]:.6f}\n")
+                f.write(f"  Avg Episode Reward: {np.mean(self.episode_reward_list):.6f}\n")
+
+        print(f"Results saved to Text: {txt_filename}")
+        return pickle_filename, txt_filename
+
+    def print_summary(self, config_info: Optional[dict] = None):
+        """RL-KSP 向けサマリーを表示"""
+        metrics = self.get_final_metrics()
+        print("\n" + "=" * 50)
+        print("RL-KSP TEST SUMMARY")
+        print("=" * 50)
+
+        if self.test_approximation_rate_list:
+            print(f"Avg Test Approx Rate (KSP-ILP base): {metrics['avg_test_approx_rate']:.2f}%")
+        if metrics['exact_approx_rate'] is not None:
+            print(f"Avg Test Approx Rate (Exact base): {metrics['exact_approx_rate']:.2f}%")
+        else:
+            print("Avg Test Approx Rate (Exact base): N/A")
+        if metrics['avg_rl_load'] is not None:
+            print(f"Avg RL Load Factor: {metrics['avg_rl_load']:.6f}")
+        if metrics['avg_ksp_ilp_load'] is not None:
+            print(f"Avg KSP-ILP Load Factor: {metrics['avg_ksp_ilp_load']:.6f}")
+
+        print("\nTIME METRICS:")
+        print(f"Total Training Time: {metrics['total_train_time']:.2f}s")
+        print(f"Total Test Time: {metrics['total_test_time']:.2f}s")
+
+        num_train_data = config_info.get('num_train_data', 0) if config_info else 0
+        num_test_data = config_info.get('num_test_data', 0) if config_info else 0
+        time_per_data = self.calculate_time_per_data(num_train_data, num_test_data)
+        print(f"Test Time per Data: {time_per_data['test_time_per_data']:.4f}s")
+        print(f"Total Test Samples: {time_per_data['total_test_samples']}")

--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from src.rl_ksp.environment.rl_environment import MinMaxLoadKSPsEnv
 from src.rl_ksp.models.dqn_model import DQNModel
 from src.common.data_management.dataset_reader import DatasetReader
-from src.gcn.train.metrics import MetricsLogger
+from src.rl_ksp.train.metrics import RLKSPMetricsLogger
 from src.common.solvers.exact_ilp import SolveExactSolution
 from src.common.config.paths import (
     get_model_root,
@@ -82,7 +82,7 @@ class RLTrainer:
         # 結果保存とメトリクス
         self.results_dir = Path('./results')
         self.results_dir.mkdir(exist_ok=True)
-        self.metrics_logger = MetricsLogger(save_dir="logs")
+        self.metrics_logger = RLKSPMetricsLogger(save_dir="logs")
         
         # 厳密解計算用の設定
         self.solver_type = config.get('solver_type', 'pulp')

--- a/src/rl_ksp/train/rl_trainer.py
+++ b/src/rl_ksp/train/rl_trainer.py
@@ -423,12 +423,18 @@ class RLTrainer:
         self.env.enable_step_profiling = True
         self.env.reset_step_phase_times()
 
-        # gt_load_factor をテスト開始前に一括キャッシュ（エピソード毎の O(N) 走査を排除）
+        # 厳密解の存在確認
         num_test_data = self.config.get('num_test_data', 20)
+        has_exact = get_exact_solution_file('test', self.config).exists()
+
+        # gt_load_factor をテスト開始前に一括キャッシュ（exact_solution.csv がある場合のみ）
         gt_load_factor_cache: Dict[int, float] = {}
-        dataset_for_cache = DatasetReader(num_test_data, 1, 'test', self.config, shuffle=False)
-        for i, batch in enumerate(dataset_for_cache):
-            gt_load_factor_cache[i] = float(np.mean(batch.load_factor))
+        if has_exact:
+            dataset_for_cache = DatasetReader(num_test_data, 1, 'test', self.config, shuffle=False)
+            for i, batch in enumerate(dataset_for_cache):
+                gt_load_factor_cache[i] = float(np.mean(batch.load_factor))
+        else:
+            print("[Info] exact_solution.csv が存在しません。厳密解ベースのメトリクスは N/A になります。")
 
         # KSP-ILP ベースラインをキャッシュ（config に K が設定されていれば）
         ksp_ilp_cache: Dict[int, float] = {}
@@ -449,10 +455,11 @@ class RLTrainer:
                 print(f"[Warning] KSP-ILP solution file not found: {ksp_ilp_file}")
 
         test_results = []
-        episode_approx_rates: List[float] = []
+        episode_approx_rates: List[float] = []        # KSP-ILP ベース (ksp_ilp / rl) × 100 — 主要メトリクス
+        episode_exact_approx_rates: List[float] = []  # 厳密解ベース (exact / rl) × 100 — exact がある場合のみ
         episode_gt_loads: List[float] = []
         episode_ksp_ilp_loads: List[float] = []
-        episode_ksp_ilp_approx_rates: List[float] = []  # 同一サンプルの gt/ksp_ilp 比
+        episode_ksp_ilp_approx_rates: List[float] = []  # 同一サンプルの gt/ksp_ilp 比（exact がある場合のみ）
         total_test_time = 0.0
         # フェーズ別累積時間
         phase_totals = {
@@ -496,31 +503,42 @@ class RLTrainer:
 
             # 実際にRLが使用したデータのインデックスを取得
             current_data_idx = getattr(self.env, 'current_used_data_idx', self.env.data_idx - 1)
-            gt_load_factor = gt_load_factor_cache.get(current_data_idx, 0.0)
 
-            # GCNと同じ計算方法: gt_load_factor / predicted_load_factor * 100
-            if max_load > 0:
-                approximation_rate = gt_load_factor / max_load * 100
-            else:
-                approximation_rate = 0.0
-
-            # デバッグ情報
-            print(f"  Debug: data_idx={current_data_idx}, gt_load={gt_load_factor:.6f}, rl_load={max_load:.6f}, approx_rate={approximation_rate:.2f}%")
-
-            # Approximation Rateが100%を超えた場合: 厳密解がratioGapによる準最適解の可能性があるためワーニングのみ
-            if approximation_rate > 100.01:
-                print(f"\n⚠️  WARNING: Approximation Rate exceeded 100% ({approximation_rate:.2f}%)")
-                print(f"   GT load ({gt_load_factor:.6f}) may be a sub-optimal solution due to solver ratioGap setting.")
-                print(f"   Episode: {episode + 1}/{test_episodes}, Data Index: {current_data_idx}")
-                print(f"   Continuing experiment...")
-
-            episode_approx_rates.append(approximation_rate)
-            episode_gt_loads.append(gt_load_factor)
+            # KSP-ILP ベースの近似率（主要メトリクス）
             if current_data_idx in ksp_ilp_cache:
                 ksp_ilp_lf = ksp_ilp_cache[current_data_idx]
                 episode_ksp_ilp_loads.append(ksp_ilp_lf)
-                if ksp_ilp_lf > 0:
+                if ksp_ilp_lf > 0 and max_load > 0:
+                    ksp_ilp_approx = ksp_ilp_lf / max_load * 100
+                    episode_approx_rates.append(ksp_ilp_approx)
+                else:
+                    ksp_ilp_approx = None
+            else:
+                ksp_ilp_lf = None
+                ksp_ilp_approx = None
+
+            # 厳密解ベースの近似率（exact_solution.csv がある場合のみ）
+            gt_load_factor = gt_load_factor_cache.get(current_data_idx, None) if has_exact else None
+            if gt_load_factor is not None and gt_load_factor > 0 and max_load > 0:
+                exact_approx = gt_load_factor / max_load * 100
+                episode_exact_approx_rates.append(exact_approx)
+                episode_gt_loads.append(gt_load_factor)
+                # KSP-ILP vs 厳密解
+                if ksp_ilp_lf is not None and ksp_ilp_lf > 0:
                     episode_ksp_ilp_approx_rates.append(gt_load_factor / ksp_ilp_lf * 100)
+            else:
+                exact_approx = None
+
+            # デバッグ情報
+            ksp_str = f"{ksp_ilp_approx:.2f}%" if ksp_ilp_approx is not None else "N/A"
+            exact_str = f"{exact_approx:.2f}%" if exact_approx is not None else "N/A"
+            print(f"  Debug: data_idx={current_data_idx}, rl_load={max_load:.6f},"
+                  f" ksp_ilp_approx={ksp_str}, exact_approx={exact_str}")
+
+            # KSP-ILP ベース近似率が 100% を超えた場合（RL が KSP-ILP より良い）はワーニングのみ
+            if ksp_ilp_approx is not None and ksp_ilp_approx > 100.01:
+                print(f"\n⚠️  WARNING: RL outperformed KSP-ILP ({ksp_ilp_approx:.2f}%)"
+                      f" at episode {episode + 1}, data_idx={current_data_idx}. Continuing...")
 
             test_results.append({
                 'episode': episode + 1,
@@ -541,13 +559,20 @@ class RLTrainer:
         # テスト結果の保存
         self._save_test_results(test_results)
 
-        # 全エピソードの平均 approximation rate を1回だけ記録（GCN と同じ粒度）
-        mean_approx_rate = float(np.mean(episode_approx_rates)) if episode_approx_rates else 0.0
+        # KSP-ILP ベースの近似率（主要メトリクス）。KSP-ILP がない場合は厳密解ベースへフォールバック
+        mean_exact_approx_rate = float(np.mean(episode_exact_approx_rates)) if episode_exact_approx_rates else None
+        if episode_approx_rates:
+            mean_approx_rate = float(np.mean(episode_approx_rates))
+        elif mean_exact_approx_rate is not None:
+            print("[Info] KSP-ILP baseline unavailable. Falling back to exact-based approx rate for primary metric.")
+            mean_approx_rate = mean_exact_approx_rate
+        else:
+            mean_approx_rate = 0.0
 
         # ベースライン比較メトリクスの計算
         avg_exact_load = float(np.mean(episode_gt_loads)) if episode_gt_loads else None
         avg_ksp_ilp_load = float(np.mean(episode_ksp_ilp_loads)) if episode_ksp_ilp_loads else None
-        # ksp_ilp_approx_rate はエピソード毎の比の平均（同一サンプルで計算）
+        # ksp_ilp_approx_rate はエピソード毎の gt/ksp_ilp 比（exact がある場合のみ）
         ksp_ilp_approx_rate = float(np.mean(episode_ksp_ilp_approx_rates)) if episode_ksp_ilp_approx_rates else None
 
         # 統計の表示（GCNと同じスタイル）
@@ -560,6 +585,7 @@ class RLTrainer:
             avg_exact_load=avg_exact_load,
             avg_ksp_ilp_load=avg_ksp_ilp_load,
             ksp_ilp_approx_rate=ksp_ilp_approx_rate,
+            exact_approx_rate=mean_exact_approx_rate,
         )
         avg_steps = np.mean([r['steps'] for r in test_results])
         avg_time = total_test_time / test_episodes
@@ -568,14 +594,21 @@ class RLTrainer:
         print(f"RL TEST RESULTS SUMMARY")
         print(f"="*50)
         print(f"Average Total Reward: {avg_reward:.6f}")
-        print(f"Average Max Load Factor: {avg_max_load:.6f}")
-        print(f"Average Approximation Rate: {mean_approx_rate:.2f}%")
+        print(f"Average RL Load Factor: {avg_max_load:.6f}")
+        print(f"Average Approx Rate (KSP-ILP base): {mean_approx_rate:.2f}%")
+        print(f"Average Approx Rate (Exact base):    "
+              f"{mean_exact_approx_rate:.2f}%" if mean_exact_approx_rate is not None else
+              f"Average Approx Rate (Exact base):    N/A")
+        if avg_ksp_ilp_load is not None:
+            print(f"Avg KSP-ILP Load Factor: {avg_ksp_ilp_load:.6f}")
         if avg_exact_load is not None:
             print(f"Avg Exact Solution Load Factor: {avg_exact_load:.6f}")
-        if avg_ksp_ilp_load is not None:
-            print(f"Avg KSP-ILP Baseline Load Factor: {avg_ksp_ilp_load:.6f}")
+        else:
+            print(f"Avg Exact Solution Load Factor: N/A")
         if ksp_ilp_approx_rate is not None:
             print(f"KSP-ILP Approx Rate (Exact/KSP-ILP): {ksp_ilp_approx_rate:.2f}%")
+        else:
+            print(f"KSP-ILP Approx Rate (Exact/KSP-ILP): N/A")
         print(f"Average Steps per Episode: {avg_steps:.2f}")
         print(f"Average Time per Episode: {avg_time:.4f}s")
         print(f"Total Test Time: {total_test_time:.2f}s")


### PR DESCRIPTION
## 概要

このブランチには以下の変更が含まれる。

1. **MetricsLogger のサブクラス分割**（`refactor`）
2. **RL-KSP 近似率ベースラインを KSP-ILP に変更・厳密解 N/A 対応**（`feat`）
3. **その他の小修正**（approx rate > 100% 警告化、RL load factor 記録、厳密解後付けスクリプト追加）

---

## 1. MetricsLogger サブクラス分割

### 背景

`src/gcn/train/metrics.py` の `MetricsLogger` が GCN・RL-KSP 両手法で共用されていたが、
RL-KSP 固有フィールドと GCN 向け RL フィールドが同一クラスに混在していた。
また `save_results()` の txt 出力に重複バグ（KSP-ILP base 行が exact-base と同値を表示）があった。

### 変更内容

| ファイル | 変更 |
|---|---|
| `src/common/train/base_metrics.py` | **新規作成** — `BaseMetricsLogger`（抽象基底） |
| `src/common/train/__init__.py` | **新規作成** |
| `src/gcn/train/metrics.py` | `MetricsLogger` → `GCNMetricsLogger` にリネーム。`MetricsLogger = GCNMetricsLogger` alias で後方互換維持 |
| `src/gcn/train/__init__.py` | `GCNMetricsLogger` をエクスポート追加 |
| `src/rl_ksp/train/metrics.py` | **新規作成** — `RLKSPMetricsLogger`（RL-KSP 専用） |
| `src/rl_ksp/train/rl_trainer.py` | `MetricsLogger` → `RLKSPMetricsLogger` に差し替え |
| `.gitignore` | `.claude/` を追加 |

### クラス設計

```
BaseMetricsLogger（抽象基底）
├── 共通フィールド: val/test_approximation_rate_list, 時間系, epochs, save_dir
├── 共通メソッド: log_val_metrics(), log_test_metrics()（基本引数のみ）, calculate_time_per_data()
├── 抽象メソッド: get_final_metrics(), save_results(), print_summary()
│
├── GCNMetricsLogger  ← src/gcn/train/metrics.py（MetricsLogger alias 維持）
│   追加: train_loss_list, comp_rate_list, rl_reward_list 等の GCN 固有フィールド
│
└── RLKSPMetricsLogger  ← src/rl_ksp/train/metrics.py（新規）
    追加: episode_reward_list, test_avg_rl_load_list, test_ksp_ilp_approx_rate_list 等
    val は no-op、Final/Best 命名を廃止して avg に統一
```

### バグ修正

`GCNMetricsLogger.save_results()` で "Approx Rate (KSP-ILP base)" が
`final_test_approximation_rate`（= exact-based rate）と同値を重複表示していた行を削除。
txt 出力の表記を "Avg Test Approx Rate (Exact base)" / "Best Test Approx Rate (Exact base)" に統一。

---

## 2. RL-KSP 近似率ベースラインを KSP-ILP に変更

### 背景

大規模コモディティ向けデータセット（`--skip-exact`）では厳密解がなく、
従来の `exact_lf / rl_load` 計算が `gt_load_factor=0.0` で誤値になっていた。

### 変更内容（`src/rl_ksp/train/rl_trainer.py`）

| 変更点 | 詳細 |
|---|---|
| 主要近似率 | `ksp_ilp_lf / rl_load × 100`（KSP-ILP ベース） |
| 副次近似率 | `exact_lf / rl_load × 100`（厳密解ある場合のみ） |
| フォールバック | KSP-ILP ファイル欠損時は厳密解ベースへ自動切替 |
| N/A 対応 | 厳密解・KSP-ILP 欠損時は該当メトリクスを `N/A` 記録 |

### 出力例

```
Avg Test Approx Rate (KSP-ILP base): 89.04%
Avg Test Approx Rate (Exact base):   91.23%  (または N/A)
Avg KSP-ILP Load Factor: 0.708520
Avg Exact Solution Load Factor: 0.706093     (または N/A)
KSP-ILP Approx Rate (Exact/KSP-ILP): 99.62% (または N/A)
```

---

## 3. その他の修正

- `approx rate > 100%` を CRITICAL ERROR → WARNING に変更
- RL-KSP テスト結果に RL 自身の load factor を記録
- `--skip-exact` で生成したデータへの厳密解後付け計算スクリプト追加（`scripts/common/compute_exact_solution.py`）

---

## 後方互換性

- `from src.gcn.train.metrics import MetricsLogger` は引き続き動作（`GCNMetricsLogger` alias）
- `from src.gcn.train import MetricsLogger` も同様
- `src/gcn/train/trainer.py`, `evaluator.py`, `hyperparameter_tuner.py` は変更不要